### PR TITLE
Fix/api storage signed urls

### DIFF
--- a/apps/web/src/app/api/images/status/[id]/route.test.ts
+++ b/apps/web/src/app/api/images/status/[id]/route.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getImageOutputs } from "../status-output";
+
+const TEST_SECRET = "test-secret-for-image-status-tests";
+
+describe("image status output URLs", () => {
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET = TEST_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env.BETTER_AUTH_SECRET;
+    } else {
+      process.env.BETTER_AUTH_SECRET = originalSecret;
+    }
+  });
+
+  it("re-signs stored output images instead of returning stale metadata URLs", () => {
+    const outputs = getImageOutputs(
+      {
+        outputImage: {
+          imageOutputs: [
+            {
+              generationId: "gen_1",
+              imageUrl: "/api/storage/generations/user/out.png",
+              storageKey: "user/out.png",
+              role: "final",
+            },
+          ],
+        },
+      },
+      "generations"
+    );
+
+    expect(outputs).toHaveLength(1);
+    const url = new URL(outputs[0]!.imageUrl!, "https://example.com");
+    expect(url.pathname).toBe("/api/storage/generations/user/out.png");
+    expect(url.searchParams.get("sig")).toMatch(/^[a-f0-9]{64}$/);
+    expect(Number(url.searchParams.get("exp"))).toBeGreaterThan(
+      Math.floor(Date.now() / 1000)
+    );
+  });
+});

--- a/apps/web/src/app/api/images/status/[id]/route.ts
+++ b/apps/web/src/app/api/images/status/[id]/route.ts
@@ -2,100 +2,17 @@ import { db } from "@repo/database";
 import { generation } from "@repo/database/schema";
 import { withApiLogging } from "@repo/shared/api-logger";
 import { auth } from "@repo/shared/auth";
-import { generateSignedImageUrl } from "@repo/shared/storage/signed-url";
 import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
+import {
+  buildStorageUrl,
+  getImageOutputs,
+  getPromptRepairNotice,
+  getResponseOutput,
+} from "../status-output";
 
 function jsonError(message: string, status = 400) {
   return NextResponse.json({ error: message }, { status });
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function stringValue(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function buildStorageUrl(bucket: string | null, key: string | null) {
-  if (!key) return undefined;
-  const resolvedBucket = bucket || "generations";
-  return generateSignedImageUrl(resolvedBucket, key);
-}
-
-function getImageOutputs(metadata: unknown, bucket: string | null) {
-  const outputImage = asRecord(asRecord(metadata).outputImage);
-  const outputs = outputImage.imageOutputs;
-  const promptRepairNotice = getPromptRepairNotice(metadata);
-  if (!Array.isArray(outputs)) return [];
-  return outputs.flatMap((item, index) => {
-    const output = asRecord(item);
-    const storageKey = stringValue(output.storageKey);
-    const imageUrl =
-      stringValue(output.imageUrl) ||
-      (storageKey ? buildStorageUrl(bucket, storageKey) : undefined);
-    const generationId = stringValue(output.generationId);
-    if (!imageUrl && !generationId) return [];
-    return [
-      {
-        generationId,
-        imageUrl,
-        imageFileId: stringValue(output.imageFileId),
-        webImageMessageId: stringValue(output.webImageMessageId),
-        webImageGroupId: stringValue(output.webImageGroupId),
-        size: stringValue(output.size),
-        revisedPrompt: stringValue(output.revisedPrompt),
-        upstreamRevisedPrompt: stringValue(output.upstreamRevisedPrompt),
-        promptRepairNotice,
-        index,
-        outputRole:
-          output.role === "agent_draft" ||
-          output.role === "choice" ||
-          output.role === "final"
-            ? output.role
-            : undefined,
-      },
-    ];
-  });
-}
-
-function getPromptRepairNotice(metadata: unknown) {
-  const repair = asRecord(asRecord(metadata).moderationPromptRepair);
-  if (repair.succeeded !== true) return undefined;
-  return stringValue(repair.notice) ||
-    "The original prompt was rejected by safety checks, so this request was generated after additional prompt adjustments.";
-}
-
-function getResponseOutput(metadata: unknown) {
-  const output = asRecord(asRecord(metadata).responseOutput);
-  return {
-    responseText: stringValue(output.responseText),
-    responseThinking: stringValue(output.responseThinking),
-    responseAgent: stringValue(output.responseAgent),
-    agentEvents: Array.isArray(output.agentEvents)
-      ? output.agentEvents
-      : undefined,
-    agentRoundCount:
-      typeof output.agentRoundCount === "number"
-        ? output.agentRoundCount
-        : undefined,
-    webConversation:
-      output.webConversation && typeof output.webConversation === "object"
-        ? output.webConversation
-        : undefined,
-    backendMember:
-      output.backendMember && typeof output.backendMember === "object"
-        ? output.backendMember
-        : undefined,
-    responsesPreviousResponse:
-      output.responsesPreviousResponse &&
-      typeof output.responsesPreviousResponse === "object"
-        ? output.responsesPreviousResponse
-        : undefined,
-  };
 }
 
 export const GET = withApiLogging(

--- a/apps/web/src/app/api/images/status/status-output.ts
+++ b/apps/web/src/app/api/images/status/status-output.ts
@@ -1,0 +1,91 @@
+import { generateSignedImageUrl } from "@repo/shared/storage/signed-url";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function buildStorageUrl(bucket: string | null, key: string | null) {
+  if (!key) return undefined;
+  const resolvedBucket = bucket || "generations";
+  return generateSignedImageUrl(resolvedBucket, key);
+}
+
+export function getPromptRepairNotice(metadata: unknown) {
+  const repair = asRecord(asRecord(metadata).moderationPromptRepair);
+  if (repair.succeeded !== true) return undefined;
+  return (
+    stringValue(repair.notice) ||
+    "The original prompt was rejected by safety checks, so this request was generated after additional prompt adjustments."
+  );
+}
+
+export function getImageOutputs(metadata: unknown, bucket: string | null) {
+  const outputImage = asRecord(asRecord(metadata).outputImage);
+  const outputs = outputImage.imageOutputs;
+  const promptRepairNotice = getPromptRepairNotice(metadata);
+  if (!Array.isArray(outputs)) return [];
+  return outputs.flatMap((item, index) => {
+    const output = asRecord(item);
+    const storageKey = stringValue(output.storageKey);
+    const imageUrl =
+      (storageKey ? buildStorageUrl(bucket, storageKey) : undefined) ||
+      stringValue(output.imageUrl);
+    const generationId = stringValue(output.generationId);
+    if (!imageUrl && !generationId) return [];
+    return [
+      {
+        generationId,
+        imageUrl,
+        imageFileId: stringValue(output.imageFileId),
+        webImageMessageId: stringValue(output.webImageMessageId),
+        webImageGroupId: stringValue(output.webImageGroupId),
+        size: stringValue(output.size),
+        revisedPrompt: stringValue(output.revisedPrompt),
+        upstreamRevisedPrompt: stringValue(output.upstreamRevisedPrompt),
+        promptRepairNotice,
+        index,
+        outputRole:
+          output.role === "agent_draft" ||
+          output.role === "choice" ||
+          output.role === "final"
+            ? output.role
+            : undefined,
+      },
+    ];
+  });
+}
+
+export function getResponseOutput(metadata: unknown) {
+  const output = asRecord(asRecord(metadata).responseOutput);
+  return {
+    responseText: stringValue(output.responseText),
+    responseThinking: stringValue(output.responseThinking),
+    responseAgent: stringValue(output.responseAgent),
+    agentEvents: Array.isArray(output.agentEvents)
+      ? output.agentEvents
+      : undefined,
+    agentRoundCount:
+      typeof output.agentRoundCount === "number"
+        ? output.agentRoundCount
+        : undefined,
+    webConversation:
+      output.webConversation && typeof output.webConversation === "object"
+        ? output.webConversation
+        : undefined,
+    backendMember:
+      output.backendMember && typeof output.backendMember === "object"
+        ? output.backendMember
+        : undefined,
+    responsesPreviousResponse:
+      output.responsesPreviousResponse &&
+      typeof output.responsesPreviousResponse === "object"
+        ? output.responsesPreviousResponse
+        : undefined,
+  };
+}

--- a/apps/web/src/features/external-api/handlers/chat-completions.ts
+++ b/apps/web/src/features/external-api/handlers/chat-completions.ts
@@ -30,6 +30,7 @@ import {
   normalizeOutputCompression,
   normalizeOutputFormat,
 } from "@/features/image-generation/output-format";
+import { uploadTemporaryImageUrls } from "@/features/image-generation/request-utils";
 import {
   DEFAULT_IMAGE_SIZE,
   getImageModel,
@@ -151,6 +152,8 @@ async function imageUrlToInputFile(params: {
   imageUrl: string;
   index: number;
   maxImageBytes: number;
+  userId?: string;
+  requestId?: string;
 }) {
   if (params.imageUrl.startsWith("data:image/")) {
     const file = parseDataImageUrl(params.imageUrl);
@@ -188,11 +191,24 @@ async function imageUrlToInputFile(params: {
     }
   );
 
+  const file = new File(
+    [data],
+    `chat-completion-input-image-${params.index + 1}`,
+    { type }
+  );
+  const uploaded = params.userId
+    ? await uploadTemporaryImageUrls(params.userId, params.requestId || "chat", [
+        file,
+      ])
+    : undefined;
+
   return {
     data,
     name: `chat-completion-input-image-${params.index + 1}`,
     type,
-    url: params.imageUrl,
+    url: uploaded?.[0]?.url || params.imageUrl,
+    storageBucket: uploaded?.[0]?.bucket,
+    storageKey: uploaded?.[0]?.key,
   } satisfies ImageInputFile;
 }
 
@@ -200,6 +216,8 @@ async function inputImageUrlsToFiles(params: {
   imageUrls: readonly string[];
   maxImageBytes: number;
   maxRequestBytes: number;
+  userId?: string;
+  requestId?: string;
 }) {
   const files = await Promise.all(
     params.imageUrls.map((imageUrl, index) =>
@@ -207,6 +225,8 @@ async function inputImageUrlsToFiles(params: {
         imageUrl,
         index,
         maxImageBytes: params.maxImageBytes,
+        userId: params.userId,
+        requestId: params.requestId,
       })
     )
   );
@@ -384,6 +404,7 @@ export const postExternalChatCompletions = withApiLogging(
     }
 
     const limits = await getPlanLimits(plan.plan);
+    const id = completionId();
     const count = parsed.data.n || 1;
     if (
       count > 1 &&
@@ -407,6 +428,8 @@ export const postExternalChatCompletions = withApiLogging(
         imageUrls: promptImageUrls,
         maxImageBytes: limits.maxFileMb * 1024 * 1024,
         maxRequestBytes: limits.maxUploadMb * 1024 * 1024,
+        userId: auth.userId,
+        requestId: id,
       });
     } catch (error) {
       return openAIImageError(
@@ -473,7 +496,6 @@ export const postExternalChatCompletions = withApiLogging(
         parsed.data.requires_responses_backend,
       agentMode: false,
     };
-    const id = completionId();
     const created = nowSeconds();
 
     if (useStreamResponse) {

--- a/apps/web/src/features/external-api/handlers/responses.ts
+++ b/apps/web/src/features/external-api/handlers/responses.ts
@@ -37,7 +37,10 @@ import {
   getImageModel,
   validateImageSize,
 } from "@/features/image-generation/resolution";
-import { DEFAULT_MAX_IMAGE_BYTES } from "@/features/image-generation/request-utils";
+import {
+  DEFAULT_MAX_IMAGE_BYTES,
+  uploadTemporaryImageUrls,
+} from "@/features/image-generation/request-utils";
 import type {
   ChatGptWebConversationState,
   ChatHistoryMessage,
@@ -456,7 +459,8 @@ function parseDataImageUrl(url: string): ImageInputFile | null {
 
 async function imageUrlToInputFile(
   imageUrl: string,
-  index: number
+  index: number,
+  options?: { userId?: string; requestId?: string }
 ): Promise<ImageInputFile | null> {
   if (imageUrl.startsWith("data:image/")) {
     return parseDataImageUrl(imageUrl);
@@ -480,17 +484,31 @@ async function imageUrlToInputFile(
       throw new Error("Input image exceeds the 25MB limit.");
     }
   );
+  const file = new File([data], `response-input-image-${index + 1}`, { type });
+  const uploaded = options?.userId
+    ? await uploadTemporaryImageUrls(options.userId, options.requestId || "responses", [
+        file,
+      ])
+    : undefined;
+
   return {
     data,
     name: `response-input-image-${index + 1}`,
     type,
-    url: imageUrl,
+    url: uploaded?.[0]?.url || imageUrl,
+    storageBucket: uploaded?.[0]?.bucket,
+    storageKey: uploaded?.[0]?.key,
   };
 }
 
-async function inputImageUrlsToFiles(imageUrls: string[]) {
+async function inputImageUrlsToFiles(
+  imageUrls: string[],
+  options?: { userId?: string; requestId?: string }
+) {
   const files = await Promise.all(
-    imageUrls.map((imageUrl, index) => imageUrlToInputFile(imageUrl, index))
+    imageUrls.map((imageUrl, index) =>
+      imageUrlToInputFile(imageUrl, index, options)
+    )
   );
   return files.filter((file): file is ImageInputFile => Boolean(file));
 }
@@ -712,10 +730,14 @@ export const postExternalResponses = withApiLogging(
     );
     const preferredBackendMemberId =
       previousContinuation?.webConversation?.accountId;
+    const requestId = responseId("resp");
 
     let images: ImageInputFile[] = [];
     try {
-      images = await inputImageUrlsToFiles(promptImageUrls);
+      images = await inputImageUrlsToFiles(promptImageUrls, {
+        userId: auth.userId,
+        requestId,
+      });
     } catch (error) {
       return openAIImageError(
         error instanceof Error ? error.message : "Failed to load input image"
@@ -751,8 +773,6 @@ export const postExternalResponses = withApiLogging(
       stream: undefined,
       rawResponsesBody: parsed.data,
     };
-
-    const requestId = responseId("resp");
 
     if (wantsImageStreamResponse(request, parsed.data.stream)) {
       return createExternalImageStreamResponse(async (emit) => {

--- a/apps/web/src/features/external-api/images.test.ts
+++ b/apps/web/src/features/external-api/images.test.ts
@@ -5,6 +5,7 @@ import {
   createJsonKeepAliveResponse,
   getExternalFinalImageOutputs,
   getImageBase64,
+  getPublicImageUrl,
   IMAGE_JSON_KEEP_ALIVE_INITIAL_WAIT_MS,
   toExternalErrorStreamData,
   toExternalGenerationUsage,
@@ -37,6 +38,7 @@ beforeEach(() => {
   storageMocks.getObjectMock.mockReset();
   storageMocks.getStorageProviderMock.mockClear();
   vi.unstubAllGlobals();
+  vi.stubEnv("BETTER_AUTH_SECRET", "test-storage-signing-secret");
 });
 
 describe("external image stream response", () => {
@@ -146,13 +148,37 @@ describe("external final image selection", () => {
       created: 123,
       data: [
         {
-          url: "https://example.com/api/storage/generations/final.png",
           revised_prompt: "final prompt",
         },
       ],
       generation_id: "gen_1",
       credits_consumed: 1,
     });
+    expect("data" in payload).toBe(true);
+    if (!("data" in payload)) throw new Error("expected image response data");
+    const url = new URL(payload.data[0]!.url!);
+    expect(url.origin).toBe("https://example.com");
+    expect(url.pathname).toBe("/api/storage/generations/final.png");
+    expect(url.searchParams.get("sig")).toMatch(/^[a-f0-9]{64}$/);
+    expect(Number(url.searchParams.get("exp"))).toBeGreaterThan(
+      Math.floor(Date.now() / 1000)
+    );
+  });
+
+  it("signs same-origin absolute storage URLs before returning them to API clients", () => {
+    const request = new Request("https://example.com/v1/images/edits");
+    const publicUrl = getPublicImageUrl(
+      request,
+      "https://example.com/api/storage/generations/user/out.png"
+    );
+
+    const url = new URL(publicUrl!);
+    expect(url.origin).toBe("https://example.com");
+    expect(url.pathname).toBe("/api/storage/generations/user/out.png");
+    expect(url.searchParams.get("sig")).toMatch(/^[a-f0-9]{64}$/);
+    expect(Number(url.searchParams.get("exp"))).toBeGreaterThan(
+      Math.floor(Date.now() / 1000)
+    );
   });
 
   it("falls back to the stored primary image when only draft outputs exist", () => {

--- a/apps/web/src/features/external-api/images.ts
+++ b/apps/web/src/features/external-api/images.ts
@@ -1,4 +1,5 @@
 import { logWarn } from "@repo/shared/logger";
+import { generateSignedImageUrl } from "@repo/shared/storage/signed-url";
 import type { ImageGenerationOperationResult } from "@/features/image-generation/operations";
 import { isContentSafetyRejection } from "@/features/image-generation/sla-classification";
 import type { GeneratedImageOutput } from "@/features/image-generation/types";
@@ -109,6 +110,13 @@ function parseLocalStorageImageUrl(
 
 export function getPublicImageUrl(request: Request, imageUrl?: string) {
   if (!imageUrl) return undefined;
+  const storageReference = parseLocalStorageImageUrl(request, imageUrl);
+  if (storageReference) {
+    return new URL(
+      generateSignedImageUrl(storageReference.bucket, storageReference.key),
+      getRequestBaseUrl(request)
+    ).toString();
+  }
   if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
     return imageUrl;
   }

--- a/apps/web/src/features/image-generation/operations.ts
+++ b/apps/web/src/features/image-generation/operations.ts
@@ -14,6 +14,7 @@ import {
   moderateContent,
 } from "@repo/shared/moderation";
 import { getStorageProvider } from "@repo/shared/storage/providers";
+import { generateSignedImageUrl } from "@repo/shared/storage/signed-url";
 import {
   getPlanCapabilitySnapshot,
   getPlanQueueSettings,
@@ -274,7 +275,7 @@ export type ImageGenerationOperationResult = {
 };
 
 async function getStoredImageUrl(bucket: string, storageKey: string) {
-  return `/api/storage/${bucket}/${storageKey}`;
+  return generateSignedImageUrl(bucket, storageKey);
 }
 
 async function toImageBuffer(result: {

--- a/apps/web/src/features/image-generation/request-utils.ts
+++ b/apps/web/src/features/image-generation/request-utils.ts
@@ -17,6 +17,21 @@ export type TemporaryUploadedImage = {
   url: string;
 };
 
+export async function getImagePublicBaseUrl() {
+  return (
+    (await getRuntimeSettingString("CONTENT_MODERATION_PUBLIC_BASE_URL")) ||
+    (await getRuntimeSettingString("NEXT_PUBLIC_APP_URL")) ||
+    (await getRuntimeSettingString("BETTER_AUTH_URL")) ||
+    ""
+  ).replace(/\/$/, "");
+}
+
+function toAbsoluteImageUrl(url: string, publicBaseUrl: string) {
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  if (!publicBaseUrl) return url;
+  return `${publicBaseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
 export function formatMegabytes(bytes: number) {
   return `${bytes / 1024 / 1024}MB`;
 }
@@ -87,10 +102,7 @@ export async function uploadTemporaryImageUrls(
   if (files.length === 0) return undefined;
 
   try {
-    const publicBaseUrl =
-      (await getRuntimeSettingString("CONTENT_MODERATION_PUBLIC_BASE_URL")) ||
-      (await getRuntimeSettingString("NEXT_PUBLIC_APP_URL")) ||
-      (await getRuntimeSettingString("BETTER_AUTH_URL"));
+    const publicBaseUrl = await getImagePublicBaseUrl();
     if (
       !(await getRuntimeSettingString("STORAGE_ENDPOINT")) &&
       !publicBaseUrl
@@ -127,9 +139,7 @@ export async function uploadTemporaryImageUrls(
         return {
           bucket,
           key,
-          url: url.startsWith("http")
-            ? url
-            : `${publicBaseUrl?.replace(/\/$/, "")}${url}`,
+          url: toAbsoluteImageUrl(url, publicBaseUrl),
         };
       })
     );


### PR DESCRIPTION
ad9019d fix external API storage image URLs
• 修外接 API 返回图片 URL 缺 sig/exp。
5cf9c9b fix image status storage output signatures
• 修 /api/images/status/[id] 的 imageOutputs。
• 原来它优先返回 metadata 里的 imageUrl，可能是不带签名的旧 /api/storage/...。
• 现在只要有 storageKey，就重新生成带 sig/exp 的签名 URL。
• 这会影响瀑布流刷新/轮询/恢复状态时拿到的图片链接。