### PR TITLE
fix docker image version and cache permissions

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -3,9 +3,6 @@
 # Image tags
 GPT2IMAGE_ENV_FILE=.env
 GPT2IMAGE_IMAGE_TAG=latest
-GPT2IMAGE_WEB_IMAGE=ghcr.io/meowfree/gpt2image-pro-web:latest
-GPT2IMAGE_MIGRATE_IMAGE=ghcr.io/meowfree/gpt2image-pro-migrate:latest
-GPT2IMAGE_PROXY_IMAGE=ghcr.io/meowfree/gpt2image-pro-chatgpt-web-proxy:latest
 
 # Public URL
 WEB_PORT=3000

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -73,8 +73,8 @@ COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder /app/apps/web/public ./apps/web/public
 
-RUN mkdir -p /app/storage /app/.gpt2image && \
-    chown -R nextjs:nodejs /app/storage /app/.gpt2image
+RUN mkdir -p /app/storage /app/.gpt2image /app/apps/web/.next/cache && \
+    chown -R nextjs:nodejs /app/storage /app/.gpt2image /app/apps/web/.next
 
 USER nextjs
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ docker compose up -d
 
 默认 compose 会启动 PostgreSQL、Web 应用、数据库迁移任务和 ChatGPT Web sidecar。首次启动默认自用模式，超管密码会写入 `app-bootstrap` volume 内的 `super-admin-credentials.txt`，也可通过日志查看。
 
+`GPT2IMAGE_IMAGE_TAG` 同时控制 Web、数据库迁移和 sidecar 镜像版本。升级时不要只改其中一个镜像；让三者使用同一个 tag，避免 Web 新版本启动但迁移任务仍停留在旧版本，导致运行时缺表或字段。
+
 启动后查看状态：
 
 ```bash
@@ -186,6 +188,13 @@ docker compose up -d
 ```
 
 如果只修改 `.env` 里的运行时配置，不需要重新构建镜像，执行 `docker compose up -d` 让容器重新创建即可。
+
+如果遇到容器内 `.next/cache` 权限错误，先拉取包含权限修复的新镜像并重建容器：
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+```
 
 如果需要从源码本地构建镜像：
 

--- a/apps/web/src/features/external-api/handlers/chat-completions.test.ts
+++ b/apps/web/src/features/external-api/handlers/chat-completions.test.ts
@@ -35,6 +35,12 @@ vi.mock("@/features/image-generation/request-utils", () => ({
   uploadTemporaryImageUrls: mocks.uploadTemporaryImageUrls,
 }));
 
+type BatchRunMockParams = {
+  count: number;
+  generationIds?: string[];
+  run: (generationId: string) => Promise<unknown>;
+};
+
 function chatCompletionsRequest(body: Record<string, unknown>) {
   return new Request("https://example.test/v1/chat/completions", {
     method: "POST",
@@ -71,7 +77,7 @@ describe("external chat completions handler streaming bridge", () => {
       creditsConsumed: 1,
     });
     mocks.runBatchImageGeneration.mockImplementation(
-      async ({ count, generationIds, run }: any) => {
+      async ({ count, generationIds, run }: BatchRunMockParams) => {
         const results = [];
         for (let index = 0; index < count; index += 1) {
           results.push(await run(generationIds?.[index] || `gen_${index + 1}`));
@@ -95,7 +101,9 @@ describe("external chat completions handler streaming bridge", () => {
 
     expect(response.headers.get("content-type")).toContain("application/json");
     expect(payload.object).toBe("chat.completion");
-    const [input, callbacks] = mocks.runImageGenerationForUser.mock.calls[0]!;
+    const call = mocks.runImageGenerationForUser.mock.calls[0];
+    if (!call) throw new Error("expected image generation to be called");
+    const [input, callbacks] = call;
     expect(input).toEqual(
       expect.objectContaining({
         stream: undefined,
@@ -119,7 +127,9 @@ describe("external chat completions handler streaming bridge", () => {
     );
     await response.json();
 
-    const [input] = mocks.runImageGenerationForUser.mock.calls[0]!;
+    const call = mocks.runImageGenerationForUser.mock.calls[0];
+    if (!call) throw new Error("expected image generation to be called");
+    const [input] = call;
     expect(input).toEqual(
       expect.objectContaining({
         model: undefined,

--- a/apps/web/src/features/external-api/handlers/chat-completions.test.ts
+++ b/apps/web/src/features/external-api/handlers/chat-completions.test.ts
@@ -5,7 +5,9 @@ const mocks = vi.hoisted(() => ({
   canUsePlanCapability: vi.fn(),
   getPlanLimits: vi.fn(),
   getUserPlan: vi.fn(),
+  runBatchImageGeneration: vi.fn(),
   runImageGenerationForUser: vi.fn(),
+  uploadTemporaryImageUrls: vi.fn(),
 }));
 
 vi.mock("@/features/external-api/auth", () => ({
@@ -23,6 +25,14 @@ vi.mock("@repo/shared/subscription/services/user-plan", () => ({
 
 vi.mock("@/features/image-generation/operations", () => ({
   runImageGenerationForUser: mocks.runImageGenerationForUser,
+}));
+
+vi.mock("@/features/image-generation/batch-runner", () => ({
+  runBatchImageGeneration: mocks.runBatchImageGeneration,
+}));
+
+vi.mock("@/features/image-generation/request-utils", () => ({
+  uploadTemporaryImageUrls: mocks.uploadTemporaryImageUrls,
 }));
 
 function chatCompletionsRequest(body: Record<string, unknown>) {
@@ -60,6 +70,16 @@ describe("external chat completions handler streaming bridge", () => {
       generationId: "gen_1",
       creditsConsumed: 1,
     });
+    mocks.runBatchImageGeneration.mockImplementation(
+      async ({ count, generationIds, run }: any) => {
+        const results = [];
+        for (let index = 0; index < count; index += 1) {
+          results.push(await run(generationIds?.[index] || `gen_${index + 1}`));
+        }
+        return results;
+      }
+    );
+    mocks.uploadTemporaryImageUrls.mockResolvedValue(undefined);
   });
 
   it("does not force upstream streaming for downstream non-stream callers", async () => {
@@ -124,13 +144,18 @@ describe("external chat completions handler streaming bridge", () => {
     await response.text();
 
     expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(mocks.runBatchImageGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbacks: expect.any(Function),
+      })
+    );
     expect(mocks.runImageGenerationForUser).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: undefined,
         rawChatCompletionsBody: expect.objectContaining({ stream: true }),
         backendRequestKind: "chat",
       }),
-      expect.any(Object)
+      undefined
     );
   });
 

--- a/apps/web/src/features/image-generation/batch-runner.ts
+++ b/apps/web/src/features/image-generation/batch-runner.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { runImageGenerationForUser } from "./operations";
+import type { runImageGenerationForUser } from "./operations";
 import type { ImageGenerationCallbacks } from "./types";
 
 export type ImageGenerationOperationResult = Awaited<

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 10
 
   migrate:
-    image: ${GPT2IMAGE_MIGRATE_IMAGE:-ghcr.io/meowfree/gpt2image-pro-migrate:latest}
+    image: ghcr.io/meowfree/gpt2image-pro-migrate:${GPT2IMAGE_IMAGE_TAG:-latest}
     env_file:
       - ${GPT2IMAGE_ENV_FILE:-.env}
     environment:
@@ -32,7 +32,7 @@ services:
     restart: "no"
 
   web:
-    image: ${GPT2IMAGE_WEB_IMAGE:-ghcr.io/meowfree/gpt2image-pro-web:latest}
+    image: ghcr.io/meowfree/gpt2image-pro-web:${GPT2IMAGE_IMAGE_TAG:-latest}
     restart: unless-stopped
     env_file:
       - ${GPT2IMAGE_ENV_FILE:-.env}
@@ -56,7 +56,7 @@ services:
         condition: service_started
 
   chatgpt-web-proxy:
-    image: ${GPT2IMAGE_PROXY_IMAGE:-ghcr.io/meowfree/gpt2image-pro-chatgpt-web-proxy:latest}
+    image: ghcr.io/meowfree/gpt2image-pro-chatgpt-web-proxy:${GPT2IMAGE_IMAGE_TAG:-latest}
     restart: unless-stopped
     environment:
       CHATGPT_WEB_PROXY_BIND: :3021

--- a/packages/shared/src/storage/providers/index.ts
+++ b/packages/shared/src/storage/providers/index.ts
@@ -1,5 +1,4 @@
 import type { StorageProvider } from "../types";
-import { getRuntimeSettingString } from "../../system-settings";
 
 /**
  * 进程级 provider 单例缓存
@@ -20,6 +19,7 @@ let cachedProvider: StorageProvider | null = null;
 export async function getStorageProvider(): Promise<StorageProvider> {
   if (cachedProvider) return cachedProvider;
 
+  const { getRuntimeSettingString } = await import("../../system-settings");
   if (await getRuntimeSettingString("STORAGE_ENDPOINT")) {
     const { s3Provider } = await import("./s3");
     cachedProvider = s3Provider;


### PR DESCRIPTION
单测 DATABASE_URL 报错
• packages/shared/src/storage/providers/index.ts
• 把 system-settings 从顶层 import 改成 getStorageProvider() 内 lazy import。
• 这样 DB-free 单测 import storage/providers 时不会立刻加载数据库。

Issue #18 Docker 问题
• docker-compose.yml
• Web / migrate / chatgpt-web-proxy 改为统一使用 GPT2IMAGE_IMAGE_TAG。
• 避免 Web 是新版本、migrate 还是旧版本导致表/字段没迁移。
• .env.docker.example
• 去掉三个单独 image 变量，避免用户配错版本。
• Dockerfile.web
• 创建 /app/apps/web/.next/cache
• chown -R nextjs:nodejs /app/apps/web/.next
• 修复容器运行时 .next/cache 写入 EACCES。
• README.md
• 补充 Docker 镜像 tag 必须一致，以及 cache 权限问题的升级方式。