### PR TITLE
feat(api): add official prompt cache keys

### DIFF
--- a/apps/web/src/features/image-generation/openai-prompt-cache.ts
+++ b/apps/web/src/features/image-generation/openai-prompt-cache.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+import type { ApiConfig } from "./types";
+
+export type OpenAIPromptCacheKeyOptions = {
+  scope: string;
+  model?: string;
+  imageModel?: string;
+  agentMode?: boolean;
+  promptOptimization?: boolean;
+  toolSignature?: string;
+};
+
+function backendScope(config: ApiConfig) {
+  const backend = config.backend;
+  if (!backend?.id) return backend?.type || "direct";
+  return [
+    backend.type,
+    backend.id,
+    backend.accountBackend,
+    backend.apiInterfaceMode,
+    backend.imagesUpstreamMode,
+    backend.chatCompletionsUpstreamMode,
+  ]
+    .filter(Boolean)
+    .join(":");
+}
+
+export function buildOpenAIPromptCacheKey(
+  config: ApiConfig,
+  options: OpenAIPromptCacheKeyOptions
+) {
+  const digest = createHash("sha256")
+    .update("gpt2image:openai-prompt-cache:v1")
+    .update("\n")
+    .update(backendScope(config))
+    .update("\n")
+    .update(options.scope)
+    .update("\n")
+    .update(options.model || "")
+    .update("\n")
+    .update(options.imageModel || "")
+    .update("\n")
+    .update(options.agentMode ? "agent" : "standard")
+    .update("\n")
+    .update(options.promptOptimization === false ? "original" : "optimized")
+    .update("\n")
+    .update(options.toolSignature || "")
+    .digest("hex")
+    .slice(0, 32);
+
+  return `g2i_${digest}`;
+}

--- a/apps/web/src/features/image-generation/responses-image.ts
+++ b/apps/web/src/features/image-generation/responses-image.ts
@@ -3,6 +3,7 @@ import {
   normalizeOutputCompression,
   normalizeOutputFormat,
 } from "./output-format";
+import { buildOpenAIPromptCacheKey } from "./openai-prompt-cache";
 import {
   AUTO_IMAGE_SIZE,
   DEFAULT_IMAGE_MODEL,
@@ -59,6 +60,7 @@ type ResponsesImageRequest = {
   };
   include: string[];
   instructions?: string;
+  prompt_cache_key?: string;
 };
 
 const RESPONSES_IMAGE_INSTRUCTIONS =
@@ -145,6 +147,22 @@ function getInstructions(params: GenerateImageParams | EditImageParams) {
   return RESPONSES_IMAGE_ORIGINAL_PROMPT_INSTRUCTIONS;
 }
 
+function toolCacheSignature(tool: ResponsesImageRequest["tools"][number]) {
+  return [
+    tool.action,
+    tool.model,
+    tool.size,
+    tool.quality,
+    tool.moderation,
+    tool.output_format,
+    tool.output_compression,
+    tool.background,
+    tool.input_image_mask ? "mask" : "",
+  ]
+    .filter((value) => value !== undefined && value !== "")
+    .join(":");
+}
+
 function normalizeQuality(quality?: string): ImageQuality | undefined {
   if (
     quality === "low" ||
@@ -206,9 +224,10 @@ export function buildResponsesImageGenerationRequest(
   if (background) tool.background = background;
 
   const instructions = getInstructions(params) || RESPONSES_IMAGE_INSTRUCTIONS;
+  const responseModel = getResponsesModel(config, params.gptModel);
 
   return {
-    model: getResponsesModel(config, params.gptModel),
+    model: responseModel,
     input: [
       {
         type: "message",
@@ -224,6 +243,13 @@ export function buildResponsesImageGenerationRequest(
     reasoning: { effort: normalizeThinking(params.thinking), summary: "auto" },
     include: ["reasoning.encrypted_content"],
     instructions,
+    prompt_cache_key: buildOpenAIPromptCacheKey(config, {
+      scope: "responses-image-generation",
+      model: responseModel,
+      imageModel: tool.model,
+      promptOptimization: params.promptOptimization,
+      toolSignature: toolCacheSignature(tool),
+    }),
   };
 }
 
@@ -267,9 +293,10 @@ export function buildResponsesImageEditRequest(
   const instructions = withResponsesImageReferenceInstructions(
     getInstructions(params) || RESPONSES_IMAGE_INSTRUCTIONS
   );
+  const responseModel = getResponsesModel(config, params.gptModel);
 
   return {
-    model: getResponsesModel(config, params.gptModel),
+    model: responseModel,
     input: [
       {
         type: "message",
@@ -288,5 +315,12 @@ export function buildResponsesImageEditRequest(
     reasoning: { effort: normalizeThinking(params.thinking), summary: "auto" },
     include: ["reasoning.encrypted_content"],
     instructions,
+    prompt_cache_key: buildOpenAIPromptCacheKey(config, {
+      scope: "responses-image-edit",
+      model: responseModel,
+      imageModel: tool.model,
+      promptOptimization: params.promptOptimization,
+      toolSignature: toolCacheSignature(tool),
+    }),
   };
 }

--- a/apps/web/src/features/image-generation/responses-native-state.test.ts
+++ b/apps/web/src/features/image-generation/responses-native-state.test.ts
@@ -294,10 +294,70 @@ describe("Responses native state cache observation", () => {
     expect(second.responsesUsage?.cachedInputTokens).toBeGreaterThan(0);
     expect(bodies[0]?.store).toBe(true);
     expect(bodies[0]).not.toHaveProperty("previous_response_id");
+    expect(bodies[0]?.prompt_cache_key).toEqual(
+      expect.stringMatching(/^g2i_[a-f0-9]{32}$/)
+    );
     expect(bodies[1]).toMatchObject({
       store: true,
       previous_response_id: "resp_first",
+      prompt_cache_key: bodies[0]?.prompt_cache_key,
     });
+  });
+
+  it("scopes official prompt cache keys to the selected Responses backend", async () => {
+    process.env.DATABASE_URL =
+      process.env.DATABASE_URL || "postgresql://test:test@127.0.0.1:5432/test";
+    const { generateChatImage } = await import("./service");
+    const bodies: Array<Record<string, unknown>> = [];
+    const imageBase64 = Buffer.from("cache-key-image").toString("base64");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body || "{}")));
+        return new Response(
+          JSON.stringify({
+            id: "resp_cache",
+            output: [
+              {
+                type: "image_generation_call",
+                status: "completed",
+                result: imageBase64,
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      })
+    );
+
+    await generateChatImage(responsesConfig(), {
+      prompt: "生成一张产品海报",
+      model: "gpt-5.4",
+      history: [],
+    });
+    await generateChatImage(
+      {
+        ...responsesConfig(),
+        backend: {
+          type: "pool-account",
+          id: "account-b",
+          accountBackend: "responses",
+        },
+      },
+      {
+        prompt: "生成一张产品海报",
+        model: "gpt-5.4",
+        history: [],
+      }
+    );
+
+    expect(bodies[0]?.prompt_cache_key).toEqual(
+      expect.stringMatching(/^g2i_[a-f0-9]{32}$/)
+    );
+    expect(bodies[1]?.prompt_cache_key).toEqual(
+      expect.stringMatching(/^g2i_[a-f0-9]{32}$/)
+    );
+    expect(bodies[1]?.prompt_cache_key).not.toBe(bodies[0]?.prompt_cache_key);
   });
 
   it("falls back to store:false for Agent when upstream rejects native state", async () => {
@@ -822,6 +882,7 @@ describe("backend isolation", () => {
         model: "gpt-5.4",
         input: "draw",
         previous_response_id: "resp_external",
+        prompt_cache_key: "caller-cache-key",
         store: true,
         tools: [{ type: "web_search" }],
         size: "1024x1024",
@@ -836,6 +897,7 @@ describe("backend isolation", () => {
     expect(body.store).toBe(false);
     expect(body.stream).toBe(false);
     expect(body.previous_response_id).toBe("resp_external");
+    expect(body.prompt_cache_key).toBe("caller-cache-key");
     expect(body.input).toBe("draw");
     expect(body.size).toBeUndefined();
     expect(body.tools).toEqual([
@@ -869,6 +931,9 @@ describe("backend isolation", () => {
 
     expect(request.store).toBe(false);
     expect("previous_response_id" in request).toBe(false);
+    expect(request.prompt_cache_key).toEqual(
+      expect.stringMatching(/^g2i_[a-f0-9]{32}$/)
+    );
     expect(request.instructions).not.toContain(
       RESPONSES_IMAGE_REFERENCE_INSTRUCTIONS
     );

--- a/apps/web/src/features/image-generation/responses-request-normalizer.ts
+++ b/apps/web/src/features/image-generation/responses-request-normalizer.ts
@@ -1,6 +1,7 @@
 export type ResponsesStreamRequestBody = Record<string, unknown> & {
   stream?: boolean;
   tools?: unknown[];
+  prompt_cache_key?: string;
 };
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/web/src/features/image-generation/responses-streaming.test.ts
+++ b/apps/web/src/features/image-generation/responses-streaming.test.ts
@@ -100,7 +100,7 @@ describe("Responses streaming parser", () => {
     const { repairModerationBlockedPromptWithResponses } = await import(
       "./service"
     );
-    const fetchMock = vi.fn(async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
       return new Response(
         JSON.stringify({
           id: "resp_repair",
@@ -163,7 +163,7 @@ describe("Responses streaming parser", () => {
         controller = nextController;
       },
     });
-    const fetchMock = vi.fn(async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => {
       return new Response(stream, {
         status: 200,
         headers: { "Content-Type": "text/plain" },
@@ -522,32 +522,34 @@ describe("Responses streaming parser", () => {
     process.env.DATABASE_URL =
       process.env.DATABASE_URL || "postgresql://test:test@127.0.0.1:5432/test";
     const { generateChatImage } = await import("./service");
-    const fetchMock = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          id: "chatcmpl_test",
-          model: "gpt-5.4",
-          choices: [
-            {
-              message: {
-                role: "assistant",
-                content: "native chat result",
-                images: [
-                  {
-                    b64_json: Buffer.from("native-image").toString("base64"),
-                    revised_prompt: "native image",
-                  },
-                ],
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit): Promise<Response> => {
+        return new Response(
+          JSON.stringify({
+            id: "chatcmpl_test",
+            model: "gpt-5.4",
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: "native chat result",
+                  images: [
+                    {
+                      b64_json: Buffer.from("native-image").toString("base64"),
+                      revised_prompt: "native image",
+                    },
+                  ],
+                },
               },
-            },
-          ],
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
-    });
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      }
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await generateChatImage(
@@ -571,9 +573,16 @@ describe("Responses streaming parser", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.test/v1/chat/completions",
       expect.objectContaining({
-        body: expect.not.stringContaining('"stream":true'),
+        body: expect.stringMatching(
+          /"prompt_cache_key":"g2i_[a-f0-9]{32}"/
+        ),
       })
     );
+    const calls = fetchMock.mock.calls;
+    const firstCall = calls[0];
+    if (!firstCall) throw new Error("expected chat completions fetch call");
+    const init = firstCall[1] as RequestInit | undefined;
+    expect(String(init?.body || "")).not.toContain('"stream":true');
   });
 
   it("streams native upstream Chat Completions only when backend streaming is enabled", async () => {
@@ -582,9 +591,9 @@ describe("Responses streaming parser", () => {
     const { generateChatImage } = await import("./service");
     const fetchMock = vi.fn(async () => {
       return new Response(
-        sseBlock("chat.completion.chunk", {
+        `${sseBlock("chat.completion.chunk", {
           choices: [{ delta: { content: "hello" } }],
-        }) + "data: [DONE]\n\n",
+        })}data: [DONE]\n\n`,
         {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },

--- a/apps/web/src/features/image-generation/service.ts
+++ b/apps/web/src/features/image-generation/service.ts
@@ -47,6 +47,7 @@ import {
   normalizeOutputCompression,
   normalizeOutputFormat,
 } from "./output-format";
+import { buildOpenAIPromptCacheKey } from "./openai-prompt-cache";
 import {
   AUTO_IMAGE_SIZE,
   DEFAULT_IMAGE_MODEL,
@@ -709,6 +710,29 @@ function toBlobPart(buffer: Buffer): BlobPart {
 
 function stripTrailingSlash(value: string) {
   return value.replace(/\/+$/, "");
+}
+
+function responseToolCacheSignature(params: {
+  tool: Record<string, unknown>;
+  additionalTools?: Record<string, unknown>[];
+}) {
+  return JSON.stringify({
+    imageTool: {
+      type: params.tool.type,
+      action: params.tool.action,
+      model: params.tool.model,
+      size: params.tool.size,
+      quality: params.tool.quality,
+      moderation: params.tool.moderation,
+      output_format: params.tool.output_format,
+      output_compression: params.tool.output_compression,
+      background: params.tool.background,
+    },
+    additionalTools: (params.additionalTools || []).map((tool) => ({
+      type: tool.type,
+      name: tool.name,
+    })),
+  });
 }
 
 function isPoolAccountBackend(
@@ -1605,6 +1629,14 @@ async function generateChatImageWithChatCompletions(
     ...(rawBody || {}),
     model,
     messages: rawBody?.messages || buildChatCompletionsMessages(params),
+    prompt_cache_key:
+      rawBody?.prompt_cache_key ||
+      buildOpenAIPromptCacheKey(config, {
+        scope: "chat-completions",
+        model,
+        imageModel: params.imageModel,
+        promptOptimization: params.promptOptimization,
+      }),
     ...(stream ? { stream: true } : {}),
   };
   delete (body as Record<string, unknown>).size;
@@ -2007,8 +2039,8 @@ function extractImageFromPayload(
   const images = (payload.data || []).filter(
     (item) => item.b64_json || item.url
   );
-  if (images.length > 0) {
-    const image = images[images.length - 1]!;
+  const image = images.at(-1);
+  if (image) {
     return toGenerateImageResult(image);
   }
 
@@ -4034,6 +4066,17 @@ export async function generateChatImage(
     const defaultAdditionalTools = params.agentMode
       ? createDefaultAgentAdditionalTools()
       : [];
+    const promptCacheKey = buildOpenAIPromptCacheKey(config, {
+      scope: params.agentMode ? "responses-agent" : "responses-chat",
+      model,
+      imageModel: toolModel,
+      agentMode: params.agentMode,
+      promptOptimization: params.promptOptimization,
+      toolSignature: responseToolCacheSignature({
+        tool,
+        additionalTools: defaultAdditionalTools,
+      }),
+    });
     const requestBody: ResponsesStreamRequestBody =
       params.rawResponsesBody && isPlainRecord(params.rawResponsesBody)
         ? normalizeResponsesImageRequestBody(params.rawResponsesBody, {
@@ -4048,6 +4091,7 @@ export async function generateChatImage(
             tools: [tool, ...defaultAdditionalTools],
             instructions,
             store: responsesPreviousResponseEnabled,
+            prompt_cache_key: promptCacheKey,
             ...(canUsePreviousResponseId
               ? { previous_response_id: previousResponsesState?.responseId }
               : {}),


### PR DESCRIPTION

  - 给我们自己构造的 Responses Chat/Agent 请求加 prompt_cache_key
  - 给 Responses 文生图 / 图生图请求加 prompt_cache_key
  - 给上游 Chat Completions 请求加 prompt_cache_key
  - prompt_cache_key 按当前选中的后端成员派生，避免不同账号共用同一个 key
  - 保留 previous_response_id 逻辑不变：仍然只在同一个 Responses 后端账号时续接
  - 外接 raw /v1/responses 透传不覆盖调用方自己的 prompt_cache_key
