### PR TITLE
fix(release): v0.5.1 — 反代登录 / 配置免重启 / 自用保存 / Docker 抠图(issue #18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ BETTER_AUTH_SECRET=your-super-secret-key-change-in-production
 # (通常与 NEXT_PUBLIC_APP_URL 相同,如 https://your-domain);不一致会导致登录回调/Cookie 域不匹配。
 BETTER_AUTH_URL=http://localhost:3000
 
+# 额外信任来源(可选,逗号分隔)。反代/多域名部署时,把实际访问域名加进来,否则
+# 浏览器 Origin 与受信来源不匹配会导致登录失败。BETTER_AUTH_URL 已自动包含,无需重复。
+# 例:BETTER_AUTH_TRUSTED_ORIGINS=https://app.example.com,https://www.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=
+
 # ============================================
 # GitHub OAuth 配置
 # ============================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 本文件记录各发布版本的变更。版本格式 `v<MAJOR>.<MINOR>.<PATCH>`。
 
+## v0.5.1 (2026-06-07)
+
+修复 Docker / 反代部署的一批登录、配置与镜像问题(issue #18 评论反馈)。
+
+### 修复
+
+- **反代后无法登录**:`trustedOrigins` 原用 `NEXT_PUBLIC_APP_URL`(被 Next 构建期内联成固定值,运行时改无效、默认 `localhost`),反代域名不被信任 → 登录 / 登出 / 改密均失败。改用运行时可读的 `BETTER_AUTH_URL`,并新增 `BETTER_AUTH_TRUSTED_ORIGINS`(逗号分隔)追加额外受信域名(反代 / 多域名部署填实际访问域名即可)。
+- **后台改配置必须重启容器才生效**:系统设置只在启动时由 bootstrap 灌入 `process.env`,而邮件 / 鉴权等同步读取器只读 `process.env`,保存后未同步 → 改邮件配置不生效、SMTP 已配仍退回 Resend、发码 400。修复:保存设置时同步写回当前进程 `process.env`,即时生效、无需重启(单实例部署)。
+- **关闭自用模式保存失败("支付模式值不对")**:支付通道 `select` 选项缺少自用部署默认的 `none` 值。新增「不启用(自用)」选项,自用模式可正常保存。
+- **Docker 镜像 ISNet 抠图(PSD 导出 / 透明回退)无法运行**:基础镜像由 alpine(musl)改为 `node:22-slim`(glibc,onnxruntime-node 仅 glibc 预编译),补拷 Next 未 trace 的 `libonnxruntime.so.1` 与 ISNet 模型,并设 `ISNET_MODEL_PATH`。
+
+> 注:登出失败、改密"密码错误"、注册"邮箱已被使用"多为上述反代 / 邮件问题的连带症状,随之修复;图库筛选(日期 / 提示词)为功能需求,后续版本提供。
+
 ## v0.5.0 (2026-06-06)
 
 新增「打散元素生成 PSD」(生成式分层 PSD 导出);Agent 多轮更稳;创作页与图片加载性能、若干积分/后台/支付/部署修复。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt2image-pro",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "turbo dev",

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -62,12 +62,23 @@ export const auth = betterAuth({
   baseURL: settingValue("BETTER_AUTH_URL", "http://localhost:3000"),
 
   /**
-   * 信任的来源
-   * 允许从这些来源发起认证请求
+   * 信任的来源(CSRF / 登录来源校验)
+   *
+   * 必须用【运行时可读】的 env:`NEXT_PUBLIC_*` 会被 Next 在构建期内联成固定值,运行时改它无效
+   * (反代后默认仍是 localhost、域名对不上 → 浏览器 Origin=反代域名不被信任 → 登录失败)。
+   * 故改用运行时读取的 `BETTER_AUTH_URL`,并支持用逗号分隔的 `BETTER_AUTH_TRUSTED_ORIGINS` 追加
+   * 额外来源(如反代域名、多个域名)。部署在反代后:把这两个设成实际访问域名即可。
    */
-  trustedOrigins: [
-    settingValue("NEXT_PUBLIC_APP_URL", "http://localhost:3000"),
-  ].filter(Boolean),
+  trustedOrigins: Array.from(
+    new Set(
+      [
+        settingValue("BETTER_AUTH_URL", "http://localhost:3000"),
+        ...settingValue("BETTER_AUTH_TRUSTED_ORIGINS")
+          .split(",")
+          .map((origin) => origin.trim()),
+      ].filter(Boolean)
+    )
+  ),
 
   /**
    * 数据库配置

--- a/packages/shared/src/system-settings/definitions.ts
+++ b/packages/shared/src/system-settings/definitions.ts
@@ -466,10 +466,11 @@ export const SYSTEM_SETTING_DEFINITIONS = [
   {
     key: "PAYMENT_PROVIDER",
     label: "支付通道",
-    description: "选择 Creem 或易支付。",
+    description: "选择 Creem 或易支付;自用模式可选「不启用」。",
     category: "payment",
     valueType: "select",
     options: [
+      { label: "不启用(自用)", value: "none" },
       { label: "Creem", value: "creem" },
       { label: "易支付", value: "epay" },
     ],
@@ -478,10 +479,11 @@ export const SYSTEM_SETTING_DEFINITIONS = [
   {
     key: "NEXT_PUBLIC_PAYMENT_PROVIDER",
     label: "前端支付通道",
-    description: "前端展示用支付通道，应与支付通道保持一致。",
+    description: "前端展示用支付通道，应与支付通道保持一致;自用模式可选「不启用」。",
     category: "payment",
     valueType: "select",
     options: [
+      { label: "不启用(自用)", value: "none" },
       { label: "Creem", value: "creem" },
       { label: "易支付", value: "epay" },
     ],

--- a/packages/shared/src/system-settings/index.ts
+++ b/packages/shared/src/system-settings/index.ts
@@ -303,6 +303,24 @@ export async function importSystemSettingsFromEnv(options?: {
     });
 
   clearSystemSettingsCache();
+
+  // 同步进 process.env:同步读取器(getProcessSettingString,如邮件 SMTP/Resend、鉴权配置)只看
+  // process.env,而 process.env 仅在启动时由 bootstrap 从 DB 灌入。若保存后不同步,后台改完邮件/
+  // 配置要重启容器才生效(否则一直读旧值、SMTP 配了仍退回 resend、发码 400)。这里写回当前进程的
+  // process.env,使改动即时生效、无需重启(单实例部署如 docker compose)。
+  for (const { key, value } of values) {
+    if (value === null || value === undefined || value === "") {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] =
+      typeof value === "string"
+        ? value.trim()
+        : typeof value === "object"
+          ? JSON.stringify(value)
+          : String(value);
+  }
+
   return values.map((value) => value.key);
 }
 


### PR DESCRIPTION
- 反代后登不进:trustedOrigins 改用运行时 BETTER_AUTH_URL + 新增 BETTER_AUTH_TRUSTED_ORIGINS, 不再依赖构建期内联的 NEXT_PUBLIC_APP_URL
- 后台改配置免重启:保存系统设置时同步写回 process.env,修邮件 SMTP 仍退 Resend / 发码 400 / 必须重启
- 关闭自用模式保存失败:支付通道新增「不启用(自用)」none 选项
- (含 v0.5.0 已加的 Docker glibc + onnxruntime .so/模型修复)