### PR TITLE
fix(marketing): 登录态下首页 CTA 直达创作页,不再跳注册/登录(issue #20)

### DIFF
--- a/apps/web/src/features/marketing/components/cta-section.tsx
+++ b/apps/web/src/features/marketing/components/cta-section.tsx
@@ -4,9 +4,13 @@ import { Button } from "@repo/ui/components/button";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import { useCurrentSession } from "@/features/auth/hooks/use-current-session";
 
 export function CTASection() {
   const t = useTranslations("CTA");
+  // 已登录用户点 CTA 应进创作页,而非注册/登录页(见 issue #20)。
+  const { data: session } = useCurrentSession();
+  const getStartedHref = session?.user ? "/dashboard/create" : "/sign-up";
 
   return (
     <section className="container py-24">
@@ -26,7 +30,7 @@ export function CTASection() {
 
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <Button size="lg" className="gap-2" asChild>
-                <Link href="/sign-up">
+                <Link href={getStartedHref}>
                   {t("getStarted")}
                   <ArrowRight className="h-4 w-4" />
                 </Link>

--- a/apps/web/src/features/marketing/components/hero-section.tsx
+++ b/apps/web/src/features/marketing/components/hero-section.tsx
@@ -4,10 +4,14 @@ import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
 import { ArrowRight } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useCurrentSession } from "@/features/auth/hooks/use-current-session";
 import { Link } from "@/i18n/routing";
 
 export function HeroSection() {
   const t = useTranslations("Hero");
+  // 已登录用户点"开始创作"应直接进创作页,而非被带去注册/登录页(见 issue #20)。
+  const { data: session } = useCurrentSession();
+  const getStartedHref = session?.user ? "/dashboard/create" : "/sign-up";
 
   return (
     <section className="container relative overflow-hidden py-20 md:py-28 lg:py-32">
@@ -36,7 +40,7 @@ export function HeroSection() {
         {/* CTAs */}
         <div className="mb-16 flex flex-col gap-4 sm:flex-row">
           <Button size="lg" className="gap-2 px-8" asChild>
-            <Link href="/sign-up">
+            <Link href={getStartedHref}>
               {t("getStarted")}
               <ArrowRight className="h-4 w-4" />
             </Link>


### PR DESCRIPTION
首页 Hero 与底部 CTA 的"开始创作"按钮原写死 href=/sign-up,已登录用户点击也被带去注册/登录页。 改用 useCurrentSession(与 Header/定价区一致):已登录 → /dashboard/create,未登录 → /sign-up。

Refs #20