### PR TITLE
feat(image): API 可关闭"审核改写重试",失败直接返回真实错误(issue #24)

### DIFF
--- a/apps/web/src/features/external-api/handlers/image-generations.ts
+++ b/apps/web/src/features/external-api/handlers/image-generations.ts
@@ -53,6 +53,9 @@ const externalImageGenerationSchema = z.object({
     .max(IMAGE_PROMPT_MAX_CHARACTERS, IMAGE_PROMPT_TOO_LONG_MESSAGE),
   promptOptimization: z.boolean().optional(),
   prompt_optimization: z.boolean().optional(),
+  // 审核改写重试开关(issue #24):传 false 时,审核拦截后不自动改写提示词重试,直接返回真实错误。
+  promptRepair: z.boolean().optional(),
+  prompt_repair: z.boolean().optional(),
   model: z.string().optional(),
   gptModel: z.string().optional(),
   gpt_model: z.string().optional(),
@@ -243,6 +246,8 @@ export const postExternalImageGenerations = withApiLogging(
       prompt: parsed.data.prompt,
       promptOptimization:
         parsed.data.promptOptimization ?? parsed.data.prompt_optimization,
+      moderationPromptRepair:
+        parsed.data.promptRepair ?? parsed.data.prompt_repair,
       moderationBlockRiskLevel: auth.moderationBlockRiskLevel,
       size: parsed.data.size || DEFAULT_IMAGE_SIZE,
       model: imageModel,

--- a/apps/web/src/features/image-generation/operations.ts
+++ b/apps/web/src/features/image-generation/operations.ts
@@ -1884,10 +1884,16 @@ async function runQueuedImageGenerationForUser({
       };
     };
 
-  const repairEnabled = await getRuntimeSettingBoolean(
-    "IMAGE_MODERATION_PROMPT_REPAIR_ENABLED",
-    true
-  );
+  // 审核改写重试开关:请求显式传 moderationPromptRepair=false 时,该次生成不做"审核拦截→自动改写
+  // 提示词→重试",失败直接返回真实错误(见 issue #24:用户希望可关闭、避免反复重试耗时、看到真实原因)。
+  // 未显式指定则沿用全局 IMAGE_MODERATION_PROMPT_REPAIR_ENABLED。
+  const repairEnabled =
+    input.moderationPromptRepair === false
+      ? false
+      : await getRuntimeSettingBoolean(
+          "IMAGE_MODERATION_PROMPT_REPAIR_ENABLED",
+          true
+        );
   const configuredRepairRetries = await getRuntimeSettingNumber(
     "IMAGE_MODERATION_PROMPT_REPAIR_MAX_RETRIES",
     1,

--- a/apps/web/src/features/image-generation/types.ts
+++ b/apps/web/src/features/image-generation/types.ts
@@ -19,6 +19,8 @@ export interface GenerateImageParams {
   mixWebFirst?: boolean;
   forceWebBackend?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
+  moderationPromptRepair?: boolean;
 }
 
 export interface GenerateImageResult {
@@ -168,6 +170,8 @@ export interface EditImageParams {
   mixWebFirst?: boolean;
   forceWebBackend?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
+  moderationPromptRepair?: boolean;
 }
 
 export interface ChatImageParams {
@@ -203,6 +207,8 @@ export interface ChatImageParams {
   chatCompletionsUpstreamMode?: "responses" | "chat_completions";
   mixWebFirst?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
+  moderationPromptRepair?: boolean;
 }
 
 export interface ChatGptWebConversationState {


### PR DESCRIPTION
生成被内容审核拦截后,系统会自动改写提示词并重试,反复重试耗时且掩盖了真实原因。
现支持请求级开关:v1/images/generations 新增 prompt_repair(=false 时本次不做审核改写重试, 直接返回真实错误)。默认沿用全局 IMAGE_MODERATION_PROMPT_REPAIR_ENABLED,行为不变。

Refs #24