### PR TITLE
feat(billing): 账单/用量每条记录显示消耗的 API Key(issue #26)

### DIFF
--- a/apps/web/src/features/settings/components/billing-section.tsx
+++ b/apps/web/src/features/settings/components/billing-section.tsx
@@ -53,6 +53,8 @@ type BillingTransaction = {
   amount: number;
   description: string | null;
   metadata: Record<string, unknown> | null;
+  /** 该笔消耗对应的外部 API Key 名称(issue #26),非 API Key 消耗或历史记录为 null。 */
+  apiKeyName?: string | null;
   createdAt: Date | string;
 };
 
@@ -431,11 +433,21 @@ export function BillingSection({ timeZone }: { timeZone: string }) {
                   <div className="col-span-3 text-muted-foreground">
                     {formatDate(tx.createdAt, locale, timeZone)}
                   </div>
-                  <div
-                    className="col-span-4 truncate"
-                    title={getBillingDescription(tx, locale)}
-                  >
-                    {getBillingDescription(tx, locale)}
+                  <div className="col-span-4 min-w-0">
+                    <div
+                      className="truncate"
+                      title={getBillingDescription(tx, locale)}
+                    >
+                      {getBillingDescription(tx, locale)}
+                    </div>
+                    {tx.apiKeyName ? (
+                      <div
+                        className="truncate text-xs text-muted-foreground"
+                        title={tx.apiKeyName}
+                      >
+                        API Key: {tx.apiKeyName}
+                      </div>
+                    ) : null}
                   </div>
                   <div className="col-span-2 text-right font-medium">
                     {getBillingAmount(tx)}

--- a/packages/shared/src/credits/actions.ts
+++ b/packages/shared/src/credits/actions.ts
@@ -8,10 +8,10 @@
 
 import { z } from "zod";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { db } from "@repo/database";
-import { creditsTransaction } from "@repo/database/schema";
+import { creditsTransaction, externalApiKey } from "@repo/database/schema";
 import { getBaseUrl } from "../config/payment";
 import {
   isPlanAtLeast,
@@ -212,17 +212,59 @@ export const getMyTransactions = withProtectedCreditsAction("getMyTransactions")
       getUserTransactionsCount(userId),
     ]);
 
+    // 解析每条交易是哪个外部 API Key 消耗的(issue #26):从 metadata.externalApiKeyId 收集后批量查
+    // external_api_key(限定本人,防越权读他人 key),映射成"名称 (••后四位)"。历史无此字段的记录不显示。
+    const apiKeyIds = Array.from(
+      new Set(
+        transactions
+          .map((tx) => {
+            const id = (tx.metadata as Record<string, unknown> | null)
+              ?.externalApiKeyId;
+            return typeof id === "string" ? id : null;
+          })
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+    const apiKeyNameById = new Map<string, string>();
+    if (apiKeyIds.length > 0) {
+      const keys = await db
+        .select({
+          id: externalApiKey.id,
+          name: externalApiKey.name,
+          lastFour: externalApiKey.lastFour,
+        })
+        .from(externalApiKey)
+        .where(
+          and(
+            eq(externalApiKey.userId, userId),
+            inArray(externalApiKey.id, apiKeyIds)
+          )
+        );
+      for (const key of keys) {
+        apiKeyNameById.set(key.id, `${key.name} (••${key.lastFour})`);
+      }
+    }
+
     return {
-      transactions: transactions.map((tx) => ({
-        id: tx.id,
-        type: tx.type,
-        amount: tx.amount,
-        debitAccount: tx.debitAccount,
-        creditAccount: tx.creditAccount,
-        description: tx.description,
-        metadata: tx.metadata as Record<string, unknown> | null,
-        createdAt: tx.createdAt,
-      })),
+      transactions: transactions.map((tx) => {
+        const metadata = tx.metadata as Record<string, unknown> | null;
+        const apiKeyId = metadata?.externalApiKeyId;
+        const apiKeyName =
+          typeof apiKeyId === "string"
+            ? (apiKeyNameById.get(apiKeyId) ?? null)
+            : null;
+        return {
+          id: tx.id,
+          type: tx.type,
+          amount: tx.amount,
+          debitAccount: tx.debitAccount,
+          creditAccount: tx.creditAccount,
+          description: tx.description,
+          metadata,
+          apiKeyName,
+          createdAt: tx.createdAt,
+        };
+      }),
       totalCount,
     };
   });


### PR DESCRIPTION
扣费交易已在 metadata.externalApiKeyId 记录了消耗来源;getMyTransactions 据此批量解析对应 external_api_key 的名称(限定本人,防越权),账单历史每条记录在描述下展示"API Key: 名称 (••后四位)"。 非 API Key 消耗或历史无该字段的记录不显示。

Refs #26