### PR TITLE
Feat/issue 27 transparent matte toggle

### DIFF
--- a/apps/web/src/app/api/images/chat/route.ts
+++ b/apps/web/src/app/api/images/chat/route.ts
@@ -848,6 +848,12 @@ export const POST = withApiLogging(async (request: NextRequest) => {
   ) {
     return errorResponse("Invalid background.");
   }
+  // 透明背景抠图回退显式开关(issue #27):chat/瀑布流可用,agent 由下游忽略。
+  const transparentMatte = getOptionalBoolean(
+    formData,
+    "transparentMatte",
+    "transparent_matte"
+  );
 
   const thinkingValue = getText(formData, "thinking") || "low";
   if (!VALID_THINKING.has(thinkingValue as ThinkingLevel)) {
@@ -937,6 +943,7 @@ export const POST = withApiLogging(async (request: NextRequest) => {
           outputFormat,
           outputCompression,
           background,
+          transparentMatte,
           stream: useStreamResponse,
           thinking,
           agentMode,

--- a/apps/web/src/app/api/images/edit/route.ts
+++ b/apps/web/src/app/api/images/edit/route.ts
@@ -242,6 +242,12 @@ export const POST = withApiLogging(async (request: NextRequest) => {
   ) {
     return errorResponse("Invalid background.");
   }
+  // 透明背景抠图回退显式开关(issue #27)。
+  const transparentMatte = getOptionalBoolean(
+    formData,
+    "transparentMatte",
+    "transparent_matte"
+  );
   let count = 1;
   try {
     count = getCount(formData, "count", planLimits.maxBatchCount);
@@ -358,6 +364,7 @@ export const POST = withApiLogging(async (request: NextRequest) => {
           outputFormat,
           outputCompression,
           background,
+          transparentMatte,
           n: 1,
           mixWebFirst: requiresResponsesBackend ? false : mixWebFirst,
           requiresResponsesBackend,

--- a/apps/web/src/app/api/images/generate/route.ts
+++ b/apps/web/src/app/api/images/generate/route.ts
@@ -52,6 +52,8 @@ const generateImageSchema = z.object({
   output_format: z.enum(["png", "jpeg", "webp"]).optional(),
   outputFormat: z.enum(["png", "jpeg", "webp"]).optional(),
   background: z.enum(["transparent", "opaque", "auto"]).optional(),
+  transparentMatte: z.boolean().optional(),
+  transparent_matte: z.boolean().optional(),
   output_compression: z.number().int().min(0).max(100).optional(),
   outputCompression: z.number().int().min(0).max(100).optional(),
   mixWebFirst: z.boolean().optional(),
@@ -131,6 +133,8 @@ export const POST = withApiLogging(async (request: NextRequest) => {
       parsed.data.output_format || parsed.data.outputFormat
     ),
     background: parsed.data.background,
+    transparentMatte:
+      parsed.data.transparentMatte ?? parsed.data.transparent_matte,
     outputCompression: normalizeOutputCompression(
       parsed.data.output_compression ?? parsed.data.outputCompression
     ),

--- a/apps/web/src/features/docs/system-docs.tsx
+++ b/apps/web/src/features/docs/system-docs.tsx
@@ -818,7 +818,13 @@ curl https://your-domain.example/v1/images/task_... \\
               name: "background",
               requirement: "可选",
               description:
-                "transparent、opaque、auto。透明背景需要命中的上游模型支持，通常还需要 output_format 为 png 或 webp；不支持的模型会返回类似 “Transparent background is not supported for this model” 的 400 错误。无法确认支持时建议使用 auto 或 opaque。",
+                "transparent、opaque、auto。透明背景需要命中的上游模型支持，通常还需要 output_format 为 png 或 webp；不支持的模型会返回类似 “Transparent background is not supported for this model” 的 400 错误。若希望在不支持的后端也拿到透明结果，可同时传 transparent_matte=true（见下一项）。无法确认支持时建议使用 auto 或 opaque。",
+            },
+            {
+              name: "transparent_matte",
+              requirement: "可选",
+              description:
+                "默认 false。仅当 background=transparent 且显式设为 true 时生效：若命中的后端不支持透明而返回 400，则自动改为不透明重新生成，再在服务端用 ISNet 抠图得到透明 PNG。关闭时透明请求直接透传，后端不支持即返回真实 400 错误。注意只对单张生成/编辑/对话生效，不含 agent 分层模式。",
             },
             {
               name: "stream",
@@ -1101,7 +1107,13 @@ data: {"type":"image_edit.completed","index":0,"generation_id":"...","generation
               name: "background",
               requirement: "可选",
               description:
-                "transparent、opaque、auto。透明背景需要命中的上游模型支持，通常还需要 output_format 为 png 或 webp；不支持的模型会返回类似 “Transparent background is not supported for this model” 的 400 错误。无法确认支持时建议使用 auto 或 opaque。",
+                "transparent、opaque、auto。透明背景需要命中的上游模型支持，通常还需要 output_format 为 png 或 webp；不支持的模型会返回类似 “Transparent background is not supported for this model” 的 400 错误。若希望在不支持的后端也拿到透明结果，可同时传 transparent_matte=true（见下一项）。无法确认支持时建议使用 auto 或 opaque。",
+            },
+            {
+              name: "transparent_matte",
+              requirement: "可选",
+              description:
+                "默认 false。仅当 background=transparent 且显式设为 true 时生效：若命中的后端不支持透明而返回 400，则自动改为不透明重新生成，再在服务端用 ISNet 抠图得到透明 PNG。关闭时透明请求直接透传，后端不支持即返回真实 400 错误。注意只对单张生成/编辑/对话生效，不含 agent 分层模式。",
             },
             {
               name: "stream",
@@ -2527,7 +2539,13 @@ curl https://your-domain.example/v1/images/task_... \\
               name: "background",
               requirement: "Optional",
               description:
-                "transparent, opaque, or auto. Transparent backgrounds require support from the selected upstream model and usually require png or webp output. Unsupported models may return a 400 error such as “Transparent background is not supported for this model”. Use auto or opaque when support is unknown.",
+                "transparent, opaque, or auto. Transparent backgrounds require support from the selected upstream model and usually require png or webp output. Unsupported models may return a 400 error such as “Transparent background is not supported for this model”. To still get a transparent result on an unsupported backend, also pass transparent_matte=true (see next field). Use auto or opaque when support is unknown.",
+            },
+            {
+              name: "transparent_matte",
+              requirement: "Optional",
+              description:
+                "Defaults to false. Only takes effect when background=transparent and explicitly set to true: if the selected backend rejects transparent with a 400, the request is regenerated opaque and matted server-side (ISNet) into a transparent PNG. When off, transparent is passed through and an unsupported backend returns the real 400 error. Applies to single image generation/edit/chat only, not the agent layered mode.",
             },
             {
               name: "stream",
@@ -2813,7 +2831,13 @@ data: {"type":"image_edit.completed","index":0,"generation_id":"...","generation
               name: "background",
               requirement: "Optional",
               description:
-                "transparent, opaque, or auto. Transparent backgrounds require support from the selected upstream model and usually require png or webp output. Unsupported models may return a 400 error such as “Transparent background is not supported for this model”. Use auto or opaque when support is unknown.",
+                "transparent, opaque, or auto. Transparent backgrounds require support from the selected upstream model and usually require png or webp output. Unsupported models may return a 400 error such as “Transparent background is not supported for this model”. To still get a transparent result on an unsupported backend, also pass transparent_matte=true (see next field). Use auto or opaque when support is unknown.",
+            },
+            {
+              name: "transparent_matte",
+              requirement: "Optional",
+              description:
+                "Defaults to false. Only takes effect when background=transparent and explicitly set to true: if the selected backend rejects transparent with a 400, the request is regenerated opaque and matted server-side (ISNet) into a transparent PNG. When off, transparent is passed through and an unsupported backend returns the real 400 error. Applies to single image generation/edit/chat only, not the agent layered mode.",
             },
             {
               name: "stream",

--- a/apps/web/src/features/external-api/handlers/chat-completions.ts
+++ b/apps/web/src/features/external-api/handlers/chat-completions.ts
@@ -95,6 +95,9 @@ const chatCompletionSchema = z
       .optional(),
     output_format: z.enum(["png", "jpeg", "webp"]).optional(),
     output_compression: z.number().int().min(0).max(100).optional(),
+    background: z.enum(["transparent", "opaque", "auto"]).optional(),
+    transparentMatte: z.boolean().optional(),
+    transparent_matte: z.boolean().optional(),
     promptOptimization: z.boolean().optional(),
     prompt_optimization: z.boolean().optional(),
     imageModel: z.string().optional(),
@@ -481,6 +484,10 @@ export const postExternalChatCompletions = withApiLogging(
       outputCompression: normalizeOutputCompression(
         parsed.data.output_compression
       ),
+      background: parsed.data.background,
+      // 透明背景抠图回退显式开关(issue #27);chat 模式(agentMode:false)适用。
+      transparentMatte:
+        parsed.data.transparentMatte ?? parsed.data.transparent_matte,
       thinking: normalizeThinking(
         parsed.data.thinking || parsed.data.reasoning?.effort
       ),

--- a/apps/web/src/features/external-api/handlers/image-edits.ts
+++ b/apps/web/src/features/external-api/handlers/image-edits.ts
@@ -92,6 +92,8 @@ const JSON_SCALAR_FIELDS = [
   "output_format",
   "output_compression",
   "background",
+  "transparentMatte",
+  "transparent_matte",
   "n",
   "response_format",
   "model",
@@ -620,6 +622,12 @@ export const postExternalImageEdits = withApiLogging(
     if (backgroundValue && !background) {
       return openAIImageError("Invalid background.");
     }
+    // 透明背景抠图回退显式开关(issue #27)。
+    const transparentMatte = getOptionalBoolean(
+      formData,
+      "transparentMatte",
+      "transparent_matte"
+    );
 
     let count = 1;
     try {
@@ -768,6 +776,7 @@ export const postExternalImageEdits = withApiLogging(
             outputFormat,
             outputCompression,
             background,
+            transparentMatte,
             n: 1,
             forceWebBackend,
             images: await buildImages(),

--- a/apps/web/src/features/external-api/handlers/image-generations.ts
+++ b/apps/web/src/features/external-api/handlers/image-generations.ts
@@ -75,6 +75,10 @@ const externalImageGenerationSchema = z.object({
   output_format: z.enum(["png", "jpeg", "webp"]).optional(),
   output_compression: z.number().int().min(0).max(100).optional(),
   background: z.enum(["transparent", "opaque", "auto"]).optional(),
+  // 透明背景抠图回退显式开关(issue #27):true 且 background=transparent 时,后端不支持透明则
+  // 服务端 ISNet 抠图得到透明结果;不传则透明直接透传、不支持即返回真实错误。
+  transparentMatte: z.boolean().optional(),
+  transparent_matte: z.boolean().optional(),
   force_web: z.boolean().optional(),
   forceWeb: z.boolean().optional(),
   web_first: z.boolean().optional(),
@@ -236,6 +240,8 @@ export const postExternalImageGenerations = withApiLogging(
       }
     }
     const background = parsed.data.background;
+    const transparentMatte =
+      parsed.data.transparentMatte ?? parsed.data.transparent_matte;
 
     const input = {
       mode: "generate" as const,
@@ -260,6 +266,7 @@ export const postExternalImageGenerations = withApiLogging(
         parsed.data.output_compression
       ),
       background,
+      transparentMatte,
       forceWebBackend:
         parsed.data.web_first ??
         parsed.data.webFirst ??

--- a/apps/web/src/features/image-generation/components/create-page-client.tsx
+++ b/apps/web/src/features/image-generation/components/create-page-client.tsx
@@ -814,10 +814,14 @@ function ImageSizeDialog({
                   </Button>
                   {customRatioOpen && (
                     <div className="space-y-2 rounded-xl border border-border bg-background p-3">
-                      <label className="text-xs font-medium text-muted-foreground">
+                      <label
+                        htmlFor="create-custom-ratio"
+                        className="text-xs font-medium text-muted-foreground"
+                      >
                         {copy("Custom ratio", "输入自定义比例")}
                       </label>
                       <Input
+                        id="create-custom-ratio"
                         value={customRatio}
                         onChange={(event) => setCustomRatio(event.target.value)}
                         placeholder="16:9"
@@ -842,10 +846,14 @@ function ImageSizeDialog({
                   </h3>
                   <div className="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-muted-foreground">
+                      <label
+                        htmlFor="create-custom-width"
+                        className="text-xs font-medium text-muted-foreground"
+                      >
                         {copy("Width", "宽度")}
                       </label>
                       <Input
+                        id="create-custom-width"
                         type="number"
                         min={256}
                         max={MAX_IMAGE_DIMENSION}
@@ -858,10 +866,14 @@ function ImageSizeDialog({
                     </div>
                     <div className="pb-2 text-muted-foreground">x</div>
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-muted-foreground">
+                      <label
+                        htmlFor="create-custom-height"
+                        className="text-xs font-medium text-muted-foreground"
+                      >
                         {copy("Height", "高度")}
                       </label>
                       <Input
+                        id="create-custom-height"
                         type="number"
                         min={256}
                         max={MAX_IMAGE_DIMENSION}
@@ -911,11 +923,13 @@ function ImageSizeDialog({
 
           {showMixRouting && (
             <label
+              htmlFor="create-mix-web-first"
               className={`flex items-start gap-3 rounded-2xl border border-border bg-muted/20 p-4 text-xs leading-5 text-muted-foreground ${
                 mixRoutingAvailable ? "cursor-pointer" : "cursor-not-allowed"
               }`}
             >
               <Checkbox
+                id="create-mix-web-first"
                 checked={effectiveMixWebFirst}
                 onCheckedChange={(checked) => setMixWebFirst(checked === true)}
                 disabled={!mixRoutingAvailable}
@@ -5082,6 +5096,7 @@ export function CreatePageClient({
         <div className="mt-2 space-y-1 border-t border-border pt-2">
           {task.events.slice(-3).map((event, index) => (
             <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: 事件为追加型日志、仅取末3条且不重排,index 与状态组合作 key 安全
               key={`${task.key}-event-${event.status || ""}-${index}`}
               className="flex items-center gap-2 text-[11px] text-muted-foreground"
             >
@@ -5153,6 +5168,7 @@ export function CreatePageClient({
                 <div className="mt-3 space-y-1 border-t border-border pt-2">
                   {round.notes.map((note, noteIndex) => (
                     <p
+                      // biome-ignore lint/suspicious/noArrayIndexKey: round notes 为追加型、不重排,noteIndex 作 key 安全
                       key={`${round.key}-note-${noteIndex}`}
                       className="whitespace-pre-wrap break-words text-[11px] leading-relaxed text-muted-foreground"
                     >
@@ -6767,7 +6783,7 @@ export function CreatePageClient({
     }, "image/png");
   };
 
-  const useResultAsReference = async (sourceResult = result) => {
+  const applyResultAsReference = async (sourceResult = result) => {
     if (!sourceResult?.imageUrl) return;
 
     try {
@@ -7375,7 +7391,7 @@ export function CreatePageClient({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => useResultAsReference(modeResult)}
+                  onClick={() => applyResultAsReference(modeResult)}
                 >
                   <RefreshCcw className="mr-2 h-4 w-4" />
                   {copy("Edit this", "编辑这张")}

--- a/apps/web/src/features/image-generation/components/create-page-client.tsx
+++ b/apps/web/src/features/image-generation/components/create-page-client.tsx
@@ -2195,6 +2195,13 @@ export function CreatePageClient({
     "background",
     "auto"
   );
+  // 透明背景抠图回退显式开关(issue #27):仅 background=transparent 时有意义。开启后若后端
+  // 不支持透明,则不透明重生成 + 服务端 ISNet 抠图;不开则透明直接透传、不支持即返回真实错误。
+  // 仅文生图/图生图/chat/瀑布流可用,agent 模式不提供(UI 隐藏 + 后端忽略)。
+  const [transparentMatte, setTransparentMatte] = useCreateRuntimeState(
+    "transparentMatte",
+    false
+  );
   const [outputCompression, setOutputCompression] = useCreateRuntimeState(
     "outputCompression",
     100
@@ -3141,6 +3148,37 @@ export function CreatePageClient({
     </Select>
   );
 
+  // 透明抠图回退开关:仅当背景选为 transparent 时出现。开启后会经服务端 ISNet 抠图链路
+  // (issue #27)。agent 模式不调用此处(不渲染)。
+  const renderTransparentMatteToggle = (params: {
+    id: string;
+    disabled?: boolean;
+  }) => {
+    if (background !== "transparent") return null;
+    return (
+      <label
+        htmlFor={params.id}
+        className={`flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
+          transparentMatte
+            ? "border-primary bg-primary/10 text-primary"
+            : "border-primary/40 bg-primary/5 text-foreground"
+        }`}
+        title={copy(
+          "Transparent matte fallback: if the backend does not support transparent output, regenerate opaque then matte it server-side (ISNet) to deliver a transparent PNG. When off, transparent is passed through and an unsupported backend returns a real error.",
+          "透明抠图回退:若后端不支持透明输出,则不透明重生成后用服务端 ISNet 抠图得到透明 PNG。关闭时透明直接透传,后端不支持即返回真实错误。"
+        )}
+      >
+        <Checkbox
+          id={params.id}
+          checked={transparentMatte}
+          onCheckedChange={(checked) => setTransparentMatte(checked === true)}
+          disabled={params.disabled}
+        />
+        {copy("Matte fallback", "透明抠图回退")}
+      </label>
+    );
+  };
+
   const renderReferenceMentionMenu = (params: {
     open: boolean;
     options: ImageReferenceMentionOption[];
@@ -3565,6 +3603,10 @@ export function CreatePageClient({
       formData.append("moderation", moderation);
       formData.append("output_format", outputFormat);
       formData.append("background", background);
+      // 透明抠图回退仅 chat/瀑布流可用,agent 不传(issue #27)。
+      if (!agentMode && background === "transparent" && transparentMatte) {
+        formData.append("transparent_matte", "true");
+      }
       if (outputFormat !== "png") {
         formData.append("output_compression", String(outputCompression));
       }
@@ -5277,6 +5319,12 @@ export function CreatePageClient({
               })}
             </div>
           )}
+          {!isWebOnlyBackend &&
+            activeMode !== "agent" &&
+            renderTransparentMatteToggle({
+              id: "chat-transparent-matte",
+              disabled: isChatGenerating || chatMixWebFirstActive,
+            })}
           <Button
             type="button"
             variant="outline"
@@ -6190,6 +6238,9 @@ export function CreatePageClient({
         moderation,
         output_format: outputFormat,
         background,
+        ...(background === "transparent" && transparentMatte
+          ? { transparent_matte: true }
+          : {}),
         ...(outputFormat !== "png"
           ? { output_compression: outputCompression }
           : {}),
@@ -6360,6 +6411,10 @@ export function CreatePageClient({
     formData.append("moderation", moderation);
     formData.append("output_format", outputFormat);
     formData.append("background", background);
+    // 透明抠图回退显式开关(issue #27)。
+    if (background === "transparent" && transparentMatte) {
+      formData.append("transparent_matte", "true");
+    }
     if (outputFormat !== "png") {
       formData.append("output_compression", String(outputCompression));
     }
@@ -7133,6 +7188,10 @@ export function CreatePageClient({
                   </label>
                   {renderBackgroundSelect({
                     id: `image-background-${mode}`,
+                    disabled: modeBusy || disableResponsesOnlyControls,
+                  })}
+                  {renderTransparentMatteToggle({
+                    id: `image-transparent-matte-${mode}`,
                     disabled: modeBusy || disableResponsesOnlyControls,
                   })}
                 </div>
@@ -8062,6 +8121,10 @@ export function CreatePageClient({
                         id: "edit-background",
                         disabled: isEditing || editMixWebFirstActive,
                       })}
+                      {renderTransparentMatteToggle({
+                        id: "edit-transparent-matte",
+                        disabled: isEditing || editMixWebFirstActive,
+                      })}
                     </div>
 
                     <div
@@ -8824,6 +8887,11 @@ export function CreatePageClient({
                     })}
                   </div>
                 )}
+                {!isWebOnlyBackend &&
+                  renderTransparentMatteToggle({
+                    id: "batch-transparent-matte",
+                    disabled: isBatchActive || chatMixWebFirstActive,
+                  })}
               </div>
               <div className="flex flex-wrap items-center justify-end gap-3">
                 {promptOptimizationField(

--- a/apps/web/src/features/image-generation/operations.ts
+++ b/apps/web/src/features/image-generation/operations.ts
@@ -2075,18 +2075,31 @@ async function runQueuedImageGenerationForUser({
     input.background === "transparent" &&
     input.transparentMatte === true &&
     !(input.mode === "chat" && input.agentMode === true);
+  // 不透明重生成 + 服务端 ISNet 抠图。opaque 自身失败则原样返回其错误,不去 matte。
+  const fallbackToOpaqueMatte = async () => {
+    const opaque = await attemptGeneration(undefined);
+    if (opaque.error) {
+      return opaque;
+    }
+    return applyTransparentMatte(opaque);
+  };
   const runGenerationAttempt = async () => {
     if (!transparentMatteEnabled) {
       return attemptGeneration(input.background);
     }
+    // 后端不支持透明有两条出口:generateImage/editImage 吞错后以 result.error 返回(主路径),
+    // 少数路径会 throw。两条都要触发回退,否则用户仍只看到 400。
     try {
-      return await attemptGeneration(input.background);
+      const first = await attemptGeneration(input.background);
+      if (first.error && isTransparentUnsupportedError(first.error)) {
+        return fallbackToOpaqueMatte();
+      }
+      return first;
     } catch (error) {
       if (!isTransparentUnsupportedError(error)) {
         throw error;
       }
-      const opaque = await attemptGeneration(undefined);
-      return applyTransparentMatte(opaque);
+      return fallbackToOpaqueMatte();
     }
   };
 

--- a/apps/web/src/features/image-generation/operations.ts
+++ b/apps/web/src/features/image-generation/operations.ts
@@ -2067,10 +2067,16 @@ async function runQueuedImageGenerationForUser({
           );
   };
 
-  // 透明背景回退:先直接传 transparent;若后端不支持(400),同一 generationId 内不透明
-  // 重试 + 服务端 ISNet 抠图得到透明结果(不额外扣费)。chat 模式不涉及 background。
+  // 透明背景抠图回退(显式开关,issue #27):仅当请求显式 transparentMatte=true 且 background=transparent
+  // 时,后端不支持透明(400)则在同一 generationId 内不透明重生成 + 服务端 ISNet 抠图得到透明结果
+  // (不额外扣费)。覆盖文生图/图生图/chat/瀑布流;agent(chat+agentMode)除外。未开启则透明直接透传,
+  // 不支持时返回真实错误(不再自动回退)。
+  const transparentMatteEnabled =
+    input.background === "transparent" &&
+    input.transparentMatte === true &&
+    !(input.mode === "chat" && input.agentMode === true);
   const runGenerationAttempt = async () => {
-    if (input.background !== "transparent" || input.mode === "chat") {
+    if (!transparentMatteEnabled) {
       return attemptGeneration(input.background);
     }
     try {

--- a/apps/web/src/features/image-generation/types.ts
+++ b/apps/web/src/features/image-generation/types.ts
@@ -19,6 +19,9 @@ export interface GenerateImageParams {
   mixWebFirst?: boolean;
   forceWebBackend?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 透明背景抠图回退(显式开关,issue #27):仅 true 且 background=transparent 时,后端不支持
+   * 透明则"不透明重生成 + 服务端 ISNet 抠图"得到透明结果;不开则透明直接透传、不支持即返回真实错误。 */
+  transparentMatte?: boolean;
   /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
   moderationPromptRepair?: boolean;
 }
@@ -170,6 +173,9 @@ export interface EditImageParams {
   mixWebFirst?: boolean;
   forceWebBackend?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 透明背景抠图回退(显式开关,issue #27):仅 true 且 background=transparent 时,后端不支持
+   * 透明则"不透明重生成 + 服务端 ISNet 抠图"得到透明结果;不开则透明直接透传、不支持即返回真实错误。 */
+  transparentMatte?: boolean;
   /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
   moderationPromptRepair?: boolean;
 }
@@ -207,6 +213,9 @@ export interface ChatImageParams {
   chatCompletionsUpstreamMode?: "responses" | "chat_completions";
   mixWebFirst?: boolean;
   requiresResponsesBackend?: boolean;
+  /** 透明背景抠图回退(显式开关,issue #27):仅 true 且 background=transparent 时,后端不支持
+   * 透明则"不透明重生成 + 服务端 ISNet 抠图"得到透明结果;不开则透明直接透传、不支持即返回真实错误。 */
+  transparentMatte?: boolean;
   /** 审核改写重试:显式 false 时本次失败不自动改写提示词重试,直接返回真实错误(issue #24)。 */
   moderationPromptRepair?: boolean;
 }


### PR DESCRIPTION
## 背景 / 动机
Closes #27。原先 background=transparent 命中不支持透明的后端时,管线会"自动"
不透明重生成 + 服务端 ISNet 抠图,悄悄改变用户产物。本 PR 把该回退改成用户
可控的显式开关,默认不再自动触发。

## 改动
- 新增显式参数 transparentMatte / transparent_matte:仅当显式开启且
  background=transparent 时,后端不支持透明(400)才在同一 generationId 内
  不透明重生成 + ISNet 抠图得到透明 PNG;未开启则透明直接透传,后端不支持
  即返回真实 400 错误。
- 覆盖范围:文生图 / 图生图 / chat / 瀑布流;agent(chat+agentMode)按设计
  排除(UI 隐藏 + 后端网关忽略)。
- 修复回退根因:generateImage/editImage/generateChatImage 把上游 400 以
  result.error 返回(而非 throw),原回退只挂在 try/catch 上从不触发。现回退
  同时识别 result.error 与 t
- 外部 API:/v1/images/generations、/v1/images/edits、/v1/chat/completions
  均支持 transparent_matte(chat-completions 同时补了 background)。
- 文档:system-docs 的 backgr  transparent_matte
  参数条目(中英)。

## 计费
回退按一张图标准价收一次:失败的透明探测不计费,ISNet 抠图为本机算力无上游
成本,不为回退机制加价。

## 验证
- turbo typecheck 通过;transa / matte 单测全绿
- biome lint 零新增 error
- 已蓝绿发布到生产并回归(公网 200、新资源 200)