### PR TITLE
feat(deploy): add lightweight Seoul stack

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -5,6 +5,22 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      next_public_app_url:
+        description: "Public application URL baked into the web image"
+        required: true
+        default: "http://localhost:3000"
+        type: string
+      generations_bucket_name:
+        description: "Object storage bucket for generated images"
+        required: true
+        default: "generations"
+        type: string
+      avatars_bucket_name:
+        description: "Object storage bucket for public avatars"
+        required: true
+        default: "avatars"
+        type: string
 
 permissions:
   contents: write
@@ -66,11 +82,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NEXT_PUBLIC_APP_URL=http://localhost:3000
+            NEXT_PUBLIC_APP_URL=${{ inputs.next_public_app_url || 'http://localhost:3000' }}
             NEXT_PUBLIC_APP_NAME=GPT2IMAGE
             NEXT_PUBLIC_PAYMENT_PROVIDER=none
-            NEXT_PUBLIC_GENERATIONS_BUCKET_NAME=generations
-            NEXT_PUBLIC_AVATARS_BUCKET_NAME=avatars
+            NEXT_PUBLIC_GENERATIONS_BUCKET_NAME=${{ inputs.generations_bucket_name || 'generations' }}
+            NEXT_PUBLIC_AVATARS_BUCKET_NAME=${{ inputs.avatars_bucket_name || 'avatars' }}
+            BETTER_AUTH_URL=${{ inputs.next_public_app_url || 'http://localhost:3000' }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
@@ -84,7 +101,7 @@ jobs:
       - name: Prepare compose bundle
         run: |
           mkdir -p dist
-          cp docker-compose.yml docker-compose.build.yml .env.docker.example README.md dist/
+          cp docker-compose.yml docker-compose.seoul.yml docker-compose.build.yml .env.docker.example README.md dist/
           tar -czf gpt2image-pro-${GITHUB_REF_NAME}.compose.tar.gz -C dist .
           zip -r gpt2image-pro-${GITHUB_REF_NAME}.compose.zip dist
 

--- a/docker-compose.seoul.yml
+++ b/docker-compose.seoul.yml
@@ -1,0 +1,84 @@
+# Runs the small Seoul deployment without optional ChatGPT sidecars.
+name: gpt2image-pro-seoul
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-gpt2image}
+      POSTGRES_USER: ${POSTGRES_USER:-gpt2image}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-gpt2image} -d ${POSTGRES_DB:-gpt2image}
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    mem_limit: 512m
+    cpus: "0.5"
+    logging: *default-logging
+
+  migrate:
+    image: ghcr.io/meowfree/gpt2image-pro-migrate:${GPT2IMAGE_IMAGE_TAG:?GPT2IMAGE_IMAGE_TAG is required}
+    env_file:
+      - ${GPT2IMAGE_ENV_FILE:-.env}
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-gpt2image}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-gpt2image}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    mem_limit: 768m
+    cpus: "1.0"
+    logging: *default-logging
+
+  web:
+    image: ghcr.io/meowfree/gpt2image-pro-web:${GPT2IMAGE_IMAGE_TAG:?GPT2IMAGE_IMAGE_TAG is required}
+    restart: unless-stopped
+    init: true
+    env_file:
+      - ${GPT2IMAGE_ENV_FILE:-.env}
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-gpt2image}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-gpt2image}
+      CHATGPT_REGISTER_URL: ""
+      CHATGPT_WEB_PROXY_URL: ""
+      GPT2IMAGE_BOOTSTRAP_CREDENTIALS_PATH: /app/.gpt2image/super-admin-credentials.txt
+      THUMB_CACHE_DIR: /app/thumb-cache
+    ports:
+      - "127.0.0.1:${WEB_PORT:-3310}:3000"
+    volumes:
+      - app-bootstrap:/app/.gpt2image
+    tmpfs:
+      - /app/thumb-cache:rw,noexec,nosuid,nodev,size=268435456,uid=1001,gid=1001,mode=0700
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://127.0.0.1:3000/api/auth/get-session').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    mem_limit: 1536m
+    cpus: "1.5"
+    logging: *default-logging
+
+volumes:
+  postgres-data:
+  app-bootstrap:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -61,6 +61,13 @@ gh api repos/MeowFree/GPT2Image-Pro/branches/<dev|main>/protection/required_stat
 
 ## 已知边界 / 后续
 
+### 首尔服务器精简部署
+
+2 核、4 GB 内存服务器采用根目录的 `docker-compose.seoul.yml`，运行
+PostgreSQL、一次性迁移和 Web 服务。生产域名与
+生成图、头像桶名必须通过 `workflow_dispatch` 输入参与镜像构建。完整步骤见
+[`deploy-seoul.md`](./deploy-seoul.md)。
+
 - **第三方 Action 已钉 SHA**：`ci.yml` / `docker-release.yml` / `actions/setup` 中的第三方 Action 均钉到 40 位 commit SHA（行尾注释保留可读大版本），防 tag 重指向供应链攻击；由 dependabot 周更自动维护。升级大版本（如 checkout v5→v6）是单独的人工决策。
 - **lint 仅覆盖改动文件**：若未来对全仓做一次性 `biome format` 重排，可将门禁升级为全仓 `biome ci`。
 - **build 与 docker-build 在 PR 上各构建一次**：分别校验「代码可构建」与「镜像可打包」，刻意保留以提高鲁棒性；如需省额度可二选一。

--- a/docs/deploy-seoul.md
+++ b/docs/deploy-seoul.md
@@ -1,0 +1,61 @@
+# 首尔服务器精简部署
+
+这套部署面向 2 核、4 GB 内存的首尔服务器。运行 PostgreSQL、一次性数据库
+迁移和 Web 服务，不启动可选的 ChatGPT Web 代理与注册机。
+
+## 构建镜像
+
+从 GitHub Actions 手动运行 `docker-release.yml` 时必须填写：
+
+- `next_public_app_url`：最终公网地址，例如 `https://image.example.com`。
+- `generations_bucket_name`：生成图私有桶。
+- `avatars_bucket_name`：头像桶。
+
+这些值会写入浏览器端构建产物，只修改服务器环境变量不会完全生效。
+标签推送仍使用本地开发默认值，生产部署应按站点重新手动构建。
+
+## 最小环境变量
+
+服务器环境文件至少包含：
+
+```dotenv
+GPT2IMAGE_IMAGE_TAG=sha-<commit>
+WEB_PORT=3310
+POSTGRES_DB=gpt2image
+POSTGRES_USER=gpt2image
+POSTGRES_PASSWORD=...
+
+BETTER_AUTH_SECRET=...
+BETTER_AUTH_URL=https://image.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=https://image.example.com
+NEXT_PUBLIC_APP_URL=https://image.example.com
+
+STORAGE_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+STORAGE_REGION=auto
+STORAGE_ACCESS_KEY_ID=...
+STORAGE_SECRET_ACCESS_KEY=...
+STORAGE_BUCKET_NAME=gpt2image-seoul-uploads
+NEXT_PUBLIC_GENERATIONS_BUCKET_NAME=gpt2image-seoul-generations
+NEXT_PUBLIC_AVATARS_BUCKET_NAME=gpt2image-seoul-avatars
+
+SELF_USE_MODE_ENABLED=true
+PAYMENT_PROVIDER=none
+NEXT_PUBLIC_PAYMENT_PROVIDER=none
+CONTENT_MODERATION_ENABLED=false
+IMAGE_GENERATION_GLOBAL_CONCURRENCY=2
+```
+
+环境文件必须只保存在服务器，并设置为 `0600`。三个 R2 桶应相互隔离：
+头像桶会按公开内容处理，不能与需要签名访问的生成图共用。
+
+## 启动与验证
+
+```bash
+docker compose -f docker-compose.seoul.yml pull
+docker compose -f docker-compose.seoul.yml up -d
+docker compose -f docker-compose.seoul.yml ps
+docker compose -f docker-compose.seoul.yml logs migrate
+```
+
+Web 默认只绑定 `127.0.0.1:3310`，应通过 Cloudflare Tunnel 对外提供 HTTPS。
+确认迁移退出码为 `0`、Web 健康后，再把公网流量切到新端口。


### PR DESCRIPTION
## Summary
- add configurable production build inputs for the public URL and R2 bucket names
- add a resource-limited Seoul Compose stack with PostgreSQL, migration, and web services
- document the fresh Seoul deployment flow

## Validation
- Docker Compose config parsed successfully
- typecheck passed after Fumadocs generation
- shared tests: 532 passed
- web tests: 574 passed
- full repository lint remains blocked by existing warnings in unchanged TypeScript files