### PR TITLE
[codex] 支持固定邀请码注册

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ BETTER_AUTH_URL=http://localhost:3000
 # 例:BETTER_AUTH_TRUSTED_ORIGINS=https://app.example.com,https://www.example.com
 BETTER_AUTH_TRUSTED_ORIGINS=
 
+# 关闭自用模式后可开放注册。配置固定邀请码时，注册不发送邮件验证码；
+# 生产环境请使用至少 8 位随机值，并仅保存到部署环境或后台机密设置。
+SELF_USE_MODE_ENABLED=true
+REGISTRATION_FIXED_VERIFICATION_CODE=
+
 # ============================================
 # GitHub OAuth 配置
 # ============================================

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -220,6 +220,11 @@
         "cooldown": "Resend in {seconds}s",
         "hint": "The code expires in 10 minutes and is required to finish sign-up."
       },
+      "inviteCode": {
+        "label": "Invite code",
+        "placeholder": "Enter invite code",
+        "hint": "Enter the invite code provided by the site administrator."
+      },
       "loading": "Creating account...",
       "submit": "Create account",
       "success": "Account created successfully!",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -220,6 +220,11 @@
         "cooldown": "{seconds}秒后重发",
         "hint": "验证码 10 分钟内有效，用于完成注册。"
       },
+      "inviteCode": {
+        "label": "邀请码",
+        "placeholder": "请输入邀请码",
+        "hint": "请输入站点管理员提供的邀请码。"
+      },
       "loading": "正在创建...",
       "submit": "创建账号",
       "success": "注册成功！",

--- a/apps/web/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/apps/web/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -1,9 +1,12 @@
 import { SignUpForm } from "@/features/auth/components/sign-up-form";
+import { isRegistrationFixedCodeEnabled } from "@repo/shared/auth/registration-fixed-code";
 import { isSelfUseModeEnabled } from "@repo/shared/auth/self-use-mode";
 import { redirect } from "next/navigation";
 
 function isGoogleAuthEnabled() {
-  return Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
+  return Boolean(
+    process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+  );
 }
 
 /**
@@ -20,5 +23,10 @@ export default async function SignUpPage({
     redirect(`/${locale}/sign-in`);
   }
 
-  return <SignUpForm googleAuthEnabled={isGoogleAuthEnabled()} />;
+  return (
+    <SignUpForm
+      googleAuthEnabled={isGoogleAuthEnabled()}
+      fixedVerificationCodeEnabled={await isRegistrationFixedCodeEnabled()}
+    />
+  );
 }

--- a/apps/web/src/features/auth/components/sign-up-form.tsx
+++ b/apps/web/src/features/auth/components/sign-up-form.tsx
@@ -72,7 +72,9 @@ function isEmailDomainError(error: unknown) {
   const code = getAuthErrorCode(error);
   const message = getErrorMessage(error).toLowerCase();
 
-  return code === "EMAIL_DOMAIN_NOT_ALLOWED" || message.includes("email domain");
+  return (
+    code === "EMAIL_DOMAIN_NOT_ALLOWED" || message.includes("email domain")
+  );
 }
 
 function isVerificationCodeError(error: unknown) {
@@ -94,9 +96,13 @@ function isVerificationCodeError(error: unknown) {
  */
 interface SignUpFormProps {
   googleAuthEnabled?: boolean;
+  fixedVerificationCodeEnabled?: boolean;
 }
 
-export function SignUpForm({ googleAuthEnabled = false }: SignUpFormProps) {
+export function SignUpForm({
+  googleAuthEnabled = false,
+  fixedVerificationCodeEnabled = false,
+}: SignUpFormProps) {
   const locale = useLocale();
   const t = useTranslations("Auth.signUp");
   const tCommon = useTranslations("Auth.common");
@@ -262,8 +268,8 @@ export function SignUpForm({ googleAuthEnabled = false }: SignUpFormProps) {
             : isVerificationCodeError(result.error)
               ? t("errors.invalidVerificationCode")
               : isEmailAlreadyRegistered(result.error)
-            ? t("errors.emailAlreadyRegistered")
-            : t("errors.emailInUse")
+                ? t("errors.emailAlreadyRegistered")
+                : t("errors.emailInUse")
         );
         setIsLoading(false);
         return;
@@ -416,39 +422,56 @@ export function SignUpForm({ googleAuthEnabled = false }: SignUpFormProps) {
         {/* 验证码输入 */}
         <div className="space-y-2">
           <Label htmlFor="verificationCode">
-            {t("verificationCode.label")}
+            {fixedVerificationCodeEnabled
+              ? t("inviteCode.label")
+              : t("verificationCode.label")}
           </Label>
           <div className="flex gap-2">
             <Input
               id="verificationCode"
-              type="text"
-              inputMode="numeric"
-              maxLength={6}
-              placeholder={t("verificationCode.placeholder")}
-              value={verificationCode}
-              onChange={(e) =>
-                setVerificationCode(e.target.value.replace(/\D/g, ""))
+              type={fixedVerificationCodeEnabled ? "password" : "text"}
+              inputMode={fixedVerificationCodeEnabled ? "text" : "numeric"}
+              maxLength={fixedVerificationCodeEnabled ? 128 : 6}
+              placeholder={
+                fixedVerificationCodeEnabled
+                  ? t("inviteCode.placeholder")
+                  : t("verificationCode.placeholder")
               }
+              value={verificationCode}
+              onChange={(e) => {
+                const value = e.target.value;
+                setVerificationCode(
+                  fixedVerificationCodeEnabled
+                    ? value
+                    : value.replace(/\D/g, "")
+                );
+              }}
               disabled={isLoading}
-              autoComplete="one-time-code"
+              autoComplete={
+                fixedVerificationCodeEnabled ? "off" : "one-time-code"
+              }
               className="flex-1"
             />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleSendCode}
-              disabled={isLoading || isSendingCode || codeCooldown > 0}
-              className="shrink-0"
-            >
-              {codeCooldown > 0
-                ? t("verificationCode.cooldown", { seconds: codeCooldown })
-                : isSendingCode
-                  ? t("verificationCode.sending")
-                  : t("verificationCode.send")}
-            </Button>
+            {fixedVerificationCodeEnabled ? null : (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSendCode}
+                disabled={isLoading || isSendingCode || codeCooldown > 0}
+                className="shrink-0"
+              >
+                {codeCooldown > 0
+                  ? t("verificationCode.cooldown", { seconds: codeCooldown })
+                  : isSendingCode
+                    ? t("verificationCode.sending")
+                    : t("verificationCode.send")}
+              </Button>
+            )}
           </div>
           <p className="text-xs text-muted-foreground">
-            {t("verificationCode.hint")}
+            {fixedVerificationCodeEnabled
+              ? t("inviteCode.hint")
+              : t("verificationCode.hint")}
           </p>
         </div>
 

--- a/docs/deploy-seoul.md
+++ b/docs/deploy-seoul.md
@@ -39,11 +39,18 @@ NEXT_PUBLIC_GENERATIONS_BUCKET_NAME=gpt2image-seoul-generations
 NEXT_PUBLIC_AVATARS_BUCKET_NAME=gpt2image-seoul-avatars
 
 SELF_USE_MODE_ENABLED=true
+REGISTRATION_FIXED_VERIFICATION_CODE=
 PAYMENT_PROVIDER=none
 NEXT_PUBLIC_PAYMENT_PROVIDER=none
 CONTENT_MODERATION_ENABLED=false
 IMAGE_GENERATION_GLOBAL_CONCURRENCY=2
 ```
+
+需要小范围开放注册且暂不配置邮件服务时，将
+`SELF_USE_MODE_ENABLED` 设为 `false`，并把
+`REGISTRATION_FIXED_VERIFICATION_CODE` 设为至少 8 位的随机值。注册页会显示邀请码输入框，
+服务端继续校验邮箱域名、重复账号和封禁状态，但不会发送邮件。固定邀请码可重复使用，
+应只提供给受邀用户并定期轮换；未验证邮箱所有权时，密码找回邮件也不可依赖。
 
 环境文件必须只保存在服务器，并设置为 `0600`。三个 R2 桶应相互隔离：
 头像桶会按公开内容处理，不能与需要签名访问的生成图共用。

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
     "./auth/role-server": "./src/auth/role-server.ts",
     "./auth/self-use-mode": "./src/auth/self-use-mode.ts",
     "./auth/bootstrap-super-admin": "./src/auth/bootstrap-super-admin.ts",
+    "./auth/registration-fixed-code": "./src/auth/registration-fixed-code.ts",
     "./auth/registration-verification": "./src/auth/registration-verification.ts",
     "./safe-action": "./src/safe-action.ts",
     "./logger": "./src/logger/index.ts",

--- a/packages/shared/src/auth/registration-fixed-code-core.ts
+++ b/packages/shared/src/auth/registration-fixed-code-core.ts
@@ -1,0 +1,50 @@
+/**
+ * 固定注册邀请码的 DB-free 纯逻辑。
+ *
+ * 使用方：registration-fixed-code.ts 负责读取运行时设置，本模块只负责配置边界与恒定时间比较。
+ */
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export const REGISTRATION_FIXED_CODE_MIN_LENGTH = 8;
+export const REGISTRATION_FIXED_CODE_MAX_LENGTH = 128;
+
+/**
+ * 规范化并校验部署侧固定邀请码。
+ *
+ * @param value 系统设置或环境变量中的原始值。
+ * @returns 未配置时返回 null，配置合法时返回去除首尾空白后的邀请码。
+ * @throws 配置长度不合法时抛错并关闭注册页，避免误配置后绕过验证。
+ */
+export function normalizeRegistrationFixedCode(
+  value: string | null | undefined
+) {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+
+  if (
+    normalized.length < REGISTRATION_FIXED_CODE_MIN_LENGTH ||
+    normalized.length > REGISTRATION_FIXED_CODE_MAX_LENGTH
+  ) {
+    throw new Error(
+      `REGISTRATION_FIXED_VERIFICATION_CODE must contain ${REGISTRATION_FIXED_CODE_MIN_LENGTH}-${REGISTRATION_FIXED_CODE_MAX_LENGTH} characters`
+    );
+  }
+
+  return normalized;
+}
+
+/**
+ * 使用固定长度摘要做恒定时间比较，避免从响应时间推断邀请码内容或长度。
+ *
+ * @param configuredCode 服务端已校验的固定邀请码。
+ * @param inputCode 用户提交的邀请码。
+ * @returns 两者去除首尾空白后完全一致时返回 true。
+ */
+export function matchesRegistrationFixedCode(
+  configuredCode: string,
+  inputCode: string
+) {
+  const configuredDigest = createHash("sha256").update(configuredCode).digest();
+  const inputDigest = createHash("sha256").update(inputCode.trim()).digest();
+  return timingSafeEqual(configuredDigest, inputDigest);
+}

--- a/packages/shared/src/auth/registration-fixed-code.test.ts
+++ b/packages/shared/src/auth/registration-fixed-code.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 固定注册邀请码纯逻辑单测。
+ *
+ * 覆盖部署配置边界和恒定时间摘要比较，测试不读取数据库或真实环境变量。
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  REGISTRATION_FIXED_CODE_MAX_LENGTH,
+  REGISTRATION_FIXED_CODE_MIN_LENGTH,
+  matchesRegistrationFixedCode,
+  normalizeRegistrationFixedCode,
+} from "./registration-fixed-code-core";
+
+describe("normalizeRegistrationFixedCode", () => {
+  it("未配置或仅有空白时关闭固定邀请码模式", () => {
+    expect(normalizeRegistrationFixedCode(undefined)).toBeNull();
+    expect(normalizeRegistrationFixedCode(null)).toBeNull();
+    expect(normalizeRegistrationFixedCode("   ")).toBeNull();
+  });
+
+  it("返回去除首尾空白后的合法邀请码", () => {
+    expect(normalizeRegistrationFixedCode("  invite-2026  ")).toBe(
+      "invite-2026"
+    );
+  });
+
+  it("拒绝过短或过长的邀请码配置", () => {
+    expect(() =>
+      normalizeRegistrationFixedCode(
+        "x".repeat(REGISTRATION_FIXED_CODE_MIN_LENGTH - 1)
+      )
+    ).toThrow();
+    expect(() =>
+      normalizeRegistrationFixedCode(
+        "x".repeat(REGISTRATION_FIXED_CODE_MAX_LENGTH + 1)
+      )
+    ).toThrow();
+  });
+});
+
+describe("matchesRegistrationFixedCode", () => {
+  it("接受完全一致的邀请码并忽略用户输入首尾空白", () => {
+    expect(matchesRegistrationFixedCode("invite-2026", " invite-2026 ")).toBe(
+      true
+    );
+  });
+
+  it("拒绝内容或大小写不同的邀请码", () => {
+    expect(matchesRegistrationFixedCode("invite-2026", "invite-2025")).toBe(
+      false
+    );
+    expect(matchesRegistrationFixedCode("invite-2026", "INVITE-2026")).toBe(
+      false
+    );
+  });
+});

--- a/packages/shared/src/auth/registration-fixed-code.ts
+++ b/packages/shared/src/auth/registration-fixed-code.ts
@@ -1,0 +1,31 @@
+/**
+ * 固定注册邀请码模式。
+ *
+ * 使用方：注册页只读取是否启用；注册验证码服务读取邀请码。
+ * 配置边界与恒定时间比较位于 DB-free 的 registration-fixed-code-core.ts。
+ */
+import { getRuntimeSettingString } from "../system-settings";
+import { normalizeRegistrationFixedCode } from "./registration-fixed-code-core";
+
+/**
+ * 读取当前固定邀请码。
+ *
+ * @returns 未启用时返回 null；启用时返回服务端邀请码。
+ * @throws 配置长度不合法时抛错，调用方必须按注册不可用处理。
+ */
+export async function getRegistrationFixedCode() {
+  const configured = await getRuntimeSettingString(
+    "REGISTRATION_FIXED_VERIFICATION_CODE"
+  );
+  return normalizeRegistrationFixedCode(configured);
+}
+
+/**
+ * 判断注册页是否应显示邀请码输入模式。
+ *
+ * @returns 固定邀请码已正确配置时返回 true。
+ * @throws 配置长度不合法时抛错，避免页面展示可用但服务端无法校验。
+ */
+export async function isRegistrationFixedCodeEnabled() {
+  return Boolean(await getRegistrationFixedCode());
+}

--- a/packages/shared/src/auth/registration-verification.ts
+++ b/packages/shared/src/auth/registration-verification.ts
@@ -16,6 +16,8 @@ import {
 import { RegistrationVerificationCodeEmail } from "../mail/templates/primary-action-email";
 import { sendEmail } from "../mail/utils";
 import { isSelfUseModeEnabled } from "./self-use-mode";
+import { getRegistrationFixedCode } from "./registration-fixed-code";
+import { matchesRegistrationFixedCode } from "./registration-fixed-code-core";
 
 const PURPOSE = "registration-email-code";
 const CODE_LENGTH = 6;
@@ -45,6 +47,12 @@ export async function sendRegistrationVerificationCode(email: string) {
 
   if (await isRegistrationEmailTaken(normalizedEmail)) {
     throw new Error("Email already registered");
+  }
+
+  // 固定邀请码模式仍执行邮箱格式、域名与重复账号检查，但不创建一次性验证码，
+  // 也不调用邮件服务。该分支用于受邀小范围开放，邀请码只在注册提交时校验。
+  if (await getRegistrationFixedCode()) {
+    return { simulated: true };
   }
 
   const identifier = getIdentifier(normalizedEmail);
@@ -103,6 +111,11 @@ export async function verifyRegistrationCode(email: string, code: string) {
 
   if (!normalizedEmail || !normalizedCode) {
     return false;
+  }
+
+  const fixedCode = await getRegistrationFixedCode();
+  if (fixedCode) {
+    return matchesRegistrationFixedCode(fixedCode, normalizedCode);
   }
 
   const identifier = getIdentifier(normalizedEmail);

--- a/packages/shared/src/system-settings/definitions.ts
+++ b/packages/shared/src/system-settings/definitions.ts
@@ -25,6 +25,7 @@ export type SettingKey =
   | "MARKETING_SLA_STATUS_ENABLED"
   | "EXTERNAL_API_CORS_ENABLED"
   | "SELF_USE_MODE_ENABLED"
+  | "REGISTRATION_FIXED_VERIFICATION_CODE"
   | "BETTER_AUTH_SECRET"
   | "BETTER_AUTH_URL"
   | "GOOGLE_CLIENT_ID"
@@ -450,6 +451,15 @@ export const SYSTEM_SETTING_DEFINITIONS = [
     category: "auth",
     valueType: "boolean",
     defaultValue: true,
+  },
+  {
+    key: "REGISTRATION_FIXED_VERIFICATION_CODE",
+    label: "固定注册邀请码",
+    description:
+      "配置后，邮箱密码注册改用同一个服务端邀请码，不发送邮件验证码。建议仅用于小范围受邀开放并定期轮换。",
+    category: "auth",
+    valueType: "string",
+    secret: true,
   },
   {
     key: "BETTER_AUTH_SECRET",


### PR DESCRIPTION
## 改动

- 新增服务端固定注册邀请码模式，邀请码从运行时机密设置读取
- 注册页在该模式下显示邀请码输入框并隐藏邮件发送按钮
- 保留邮箱域名、重复账号、自用模式和封禁守门
- 使用 SHA-256 固定长度摘要做恒定时间比较
- 补充 DB-free 单测、环境示例和首尔部署说明

## 原因

首尔站需要先向受邀用户开放注册，当前阶段暂不配置 SMTP 或 Resend。固定邀请码提供一个可快速上线、可随时轮换的受控入口。

## 验证

- `pnpm turbo typecheck`
- `pnpm --filter @repo/shared test`：537 项通过
- `pnpm exec vitest run --no-file-parallelism`（apps/web）：574 项通过
- 改动文件 Biome lint 通过
- `pnpm build:web`